### PR TITLE
Fixed an issue with bursted AXI Transactions on the ICache

### DIFF
--- a/src/main/scala/vexriscv/ip/InstructionCache.scala
+++ b/src/main/scala/vexriscv/ip/InstructionCache.scala
@@ -29,7 +29,7 @@ case class InstructionCacheConfig( cacheSize : Int,
     useRegion = false,
     useLock = false,
     useQos = false,
-    useSize = false
+    useSize = true
   )
 
   def getAvalonConfig() = AvalonMMConfig.bursted(
@@ -134,6 +134,7 @@ case class InstructionCacheMemBus(p : InstructionCacheConfig) extends Bundle wit
     mm.readCmd.addr := cmd.address
     mm.readCmd.prot  := "110"
     mm.readCmd.cache := "1111"
+    mm.readCmd.size := log2Up(p.memDataWidth/8)
     if(p.wrappedMemAccess)
       mm.readCmd.setBurstWRAP()
     else


### PR DESCRIPTION
Size must be set to the number of bytes in a single burst cycle (beat). At the
moment it is set to 0 (unused) in InstructionCache.scala. As a consequence,
when a burst request is made by the cache the slave returns a 32-bit value
repeatedly because the slave thinks that it has passed the wrap boundary.

This fix implements logic for size in the InstructionCache