### PR TITLE
Avalon: Debug Clock Domain for JTAG

### DIFF
--- a/src/main/scala/vexriscv/demo/VexRiscvAvalonWithIntegratedJtag.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAvalonWithIntegratedJtag.scala
@@ -162,7 +162,7 @@ object VexRiscvAvalonWithIntegratedJtag{
               .setName("dBusAvalon")
               .addTag(ClockDomainTag(ClockDomain.current))
           }
-          case plugin: DebugPlugin => {
+          case plugin: DebugPlugin => plugin.debugClockDomain {
             plugin.io.bus.setAsDirectionLess()
             val jtag = slave(new Jtag())
               .setName("jtag")

--- a/src/main/scala/vexriscv/demo/VexRiscvAxi4WithIntegratedJtag.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAxi4WithIntegratedJtag.scala
@@ -163,7 +163,7 @@ object VexRiscvAxi4WithIntegratedJtag{
               .setName("dBusAxi")
               .addTag(ClockDomainTag(ClockDomain.current))
           }
-          case plugin: DebugPlugin => {
+          case plugin: DebugPlugin => plugin.debugClockDomain {
             plugin.io.bus.setAsDirectionLess()
             val jtag = slave(new Jtag())
               .setName("jtag")


### PR DESCRIPTION
This change ensures that the clock domain for the JTAG interface
uses the debug plugin's domain. Otherwise, resetting the processor
will put the jtag debugger in to reset as well.

See SpinalHDL/VexRiscv#48