### PR TITLE
[WIP] Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,10 @@
-language: scala
-
-notifications:
-  email:
-    on_success: never
-
-# See 'project/Version.scala'
-scala:
-   - 2.11.6
-
-sbt_args: -no-colors -J-Xss2m
-
-script:
-  - export VEXRISCV_REGRESSION_CONFIG_COUNT=100
-  - export VEXRISCV_REGRESSION_FREERTOS_COUNT=no
-  - sbt -jvm-opts travis/jvmopts.compile compile
-  - sbt -jvm-opts travis/jvmopts.test test
-
-jdk:
-  - oraclejdk8
-#  - oraclejdk7
-#  - openjdk7
-
-env:
-  - secure: "v7FHP8yK/zixpv1ML05qcRhZfDVDFdTmTPjfMZHL7gmrJveVDgze22x4tY4tB1+JEXhKuVTYvimOrX/Ok+rOOT5gVKLowv4PUQwCR+HgWVIbqjcfZNLsa369v03/p4K/zbjJSiXFahZYOXa0ApED2KWHcVfCrNsPv0UF7YZGiIa1Q/lPBwfmpN1rLih2Mpgn4KVaJky22t7JXJyVrNdGVmIA51slVbyFwFAE8Ww/0tkC+i2PUcWWRMIxtXP4iyq/9Npcq5VdqOatKfWHqAElLfKSPNMYLMlcyxyNpNx4paq8cL6fQxFcBLi9M2msz2i/qpKv30a0tzNo5bQQgucAXOQJB2Buks728upLuqsr+k25hwcqrtjyMOr9UQkt7qXAJH/0kimW7aW1yoMxbm/6mNG98X9D1EzNRewHAKatwJeFy1bw5qIuSQxPBwQMGloManrHOHGotmHKk7Y+dgM/z1UlaAdxSQuKWGXBc8QlQvif8puPYEdJMoInJNRxiWfYu06XnmzTXgMketK7RdULM9DVYzw8hzS2EIWKu8Oa0zn0PTevD2YeJNd4G8mDqO0vz5hloIc7pFsq/exQUB/kFozfCsnvhW8P+MPN0LpuSpptBQTsLWbM5BH0hd46HoWcneDdlMvVrUcgsTPmmSroIkLIEUo+Y2iN5eQHPPp85Cw="
-
-before_install:
-  # JDK fix
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
-  - cd ..
-
-  # Verilator
-  - sudo apt-get install git make autoconf g++ flex bison -y  # First time prerequisites
-  - git clone http://git.veripool.org/git/verilator   # Only first time
-  - unset VERILATOR_ROOT  # For bash
-  - cd verilator
-  - git pull        # Make sure we're up-to-date
-  - git checkout verilator_3_916
-  - autoconf        # Create ./configure script
-  - ./configure
-  - make -j$(nproc)
-  - sudo make install
-  - cd ..
-
-  - git clone https://github.com/SpinalHDL/SpinalHDL.git -b dev
-  
-  - cd VexRiscv
-  #- curl -T README.md -udolu1990:$BINTRAY_KEY https://api.bintray.com/content/spinalhdl/VexRiscv/test/0.0.4/README.md
-  #- curl -X POST -udolu1990:$BINTRAY_KEY https://api.bintray.com/content/spinalhdl/VexRiscv/test/0.0.4/publish
-  #- sbt compile
-
-
-before_cache:
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
-  - find $HOME/.sbt -name "*.lock" -delete
-
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+os: linux
+services: docker
+language: minimal
+install: skip
+addons:
+  apt:
+    packages:
+    - docker-ce
+    - pass
+script: ./travis.sh -c

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set -e
+
+#---
+
+enable_color() {
+  ENABLECOLOR='-c '
+  ANSI_RED="\033[31m"
+  ANSI_GREEN="\033[32m"
+  ANSI_YELLOW="\033[33m"
+  ANSI_BLUE="\033[34m"
+  ANSI_MAGENTA="\033[35m"
+  ANSI_CYAN="\033[36;1m"
+  ANSI_DARKCYAN="\033[36m"
+  ANSI_NOCOLOR="\033[0m"
+}
+
+disable_color() { unset ENABLECOLOR ANSI_RED ANSI_GREEN ANSI_YELLOW ANSI_BLUE ANSI_MAGENTA ANSI_CYAN ANSI_DARKCYAN ANSI_NOCOLOR; }
+
+enable_color
+
+#---
+
+# This is a trimmed down copy of
+# https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/templates/header.sh
+travis_time_start() {
+  # `date +%N` returns the date in nanoseconds. It is used as a replacement for $RANDOM, which is only available in bash.
+  travis_timer_id=`date +%N`
+  travis_start_time=$(travis_nanoseconds)
+  echo "travis_time:start:$travis_timer_id"
+}
+travis_time_finish() {
+  travis_end_time=$(travis_nanoseconds)
+  local duration=$(($travis_end_time-$travis_start_time))
+  echo "travis_time:end:$travis_timer_id:start=$travis_start_time,finish=$travis_end_time,duration=$duration"
+}
+
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+  travis_nanoseconds() {
+    date -u '+%s000000000'
+  }
+else
+  travis_nanoseconds() {
+    date -u '+%s%N'
+  }
+fi
+
+#---
+
+compileTest () {
+  export VEXRISCV_REGRESSION_CONFIG_COUNT=100
+  export VEXRISCV_REGRESSION_FREERTOS_COUNT=no
+
+  echo "travis_fold:start:compile"
+  travis_time_start
+  printf "$ANSI_BLUE[SBT] compile $ANSI_NOCOLOR\n"
+  sbt -J-Xss2m compile
+  travis_time_finish
+  echo "travis_fold:end:compile"
+
+  echo "travis_fold:start:test"
+  travis_time_start
+  printf "$ANSI_BLUE[SBT] test $ANSI_NOCOLOR\n"
+  sbt -J-Xss2m test
+  travis_time_finish
+  echo "travis_fold:end:test"
+}
+
+#---
+
+case "$1" in
+  "-t")
+    compileTest
+  ;;
+  "-c")
+    docker run --rm -itv $(pwd):/src -w /src spinalhdl/dev ./travis.sh -t
+  ;;
+  *)
+    echo "Unknown arg <$1>"
+  ;;
+esac


### PR DESCRIPTION
Related to SpinalHDL/SpinalHDL#195.

In this PR, using docker image `spinalhdl/dev` is proposed as an alternative to installing the dependencies in each Travis test/job.

While testing the current implementation, I found it surprising that tests pass when using `spinalhdl/dev`, where SpinalHDL is not installed: https://travis-ci.com/1138-4EB/VexRiscv/builds/97934350. I would expect SpinalHDL to be required because of https://github.com/SpinalHDL/VexRiscv/blob/master/.travis.yml#L48. Hence, `spinalhdl/dev` should fail and `spinalhdl/spinalhdl` should pass. Is this because SpinalHDL is installed as a dependency if not available locally when `sbt compile` is executed?