### PR TITLE
Add getPipelinedMemoryBusConfig()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.class
 *.log
 *.bak
+.*.swp
 
 # sbt specific
 .cache/

--- a/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
@@ -63,6 +63,12 @@ object DBusSimpleBus{
     useBTE = true,
     useCTI = true
   )
+
+  def getPipelinedMemoryBusConfig() = PipelinedMemoryBusConfig(
+    addressWidth = 32,
+    dataWidth = 32
+  )
+
 }
 
 case class DBusSimpleBus() extends Bundle with IMasterSlave{
@@ -178,7 +184,8 @@ case class DBusSimpleBus() extends Bundle with IMasterSlave{
   }
 
   def toPipelinedMemoryBus() : PipelinedMemoryBus = {
-    val bus = PipelinedMemoryBus(32,32)
+    val pipelinedMemoryBusConfig = DBusSimpleBus.getPipelinedMemoryBusConfig()
+    val bus = PipelinedMemoryBus(pipelinedMemoryBusConfig)
     bus.cmd.valid := cmd.valid
     bus.cmd.write := cmd.wr
     bus.cmd.address := cmd.address.resized

--- a/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
@@ -59,6 +59,11 @@ object IBusSimpleBus{
     useBTE = true,
     useCTI = true
   )
+
+  def getPipelinedMemoryBusConfig() = PipelinedMemoryBusConfig(
+    addressWidth = 32,
+    dataWidth = 32
+  )
 }
 
 
@@ -136,7 +141,8 @@ case class IBusSimpleBus(interfaceKeepData : Boolean = false) extends Bundle wit
   }
 
   def toPipelinedMemoryBus(): PipelinedMemoryBus = {
-    val bus = PipelinedMemoryBus(32,32)
+    val pipelinedMemoryBusConfig = IBusSimpleBus.getPipelinedMemoryBusConfig()
+    val bus = PipelinedMemoryBus(pipelinedMemoryBusConfig)
     bus.cmd.arbitrationFrom(cmd)
     bus.cmd.address := cmd.pc.resized
     bus.cmd.write := False


### PR DESCRIPTION
This is a trivial patch, but the lack of this function while similar ones were present for other busses, made me assume that .toPipelinedMemoryBus() didn't exist...

Tom
