### PR TITLE
enable ecall support in small config

### DIFF
--- a/src/main/scala/vexriscv/plugin/CsrPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CsrPlugin.scala
@@ -221,7 +221,7 @@ object CsrPluginConfig{
     mhartid        = null,
     misaExtensionsInit = 66,
     misaAccess     = CsrAccess.NONE,
-    mtvecAccess    = CsrAccess.NONE,
+    mtvecAccess    = CsrAccess.WRITE_ONLY,
     mtvecInit      = mtvecInit,
     mepcAccess     = CsrAccess.READ_WRITE,
     mscratchGen    = false,
@@ -229,8 +229,9 @@ object CsrPluginConfig{
     mbadaddrAccess = CsrAccess.READ_ONLY,
     mcycleAccess   = CsrAccess.NONE,
     minstretAccess = CsrAccess.NONE,
-    ecallGen       = false,
+    ecallGen       = true,
     wfiGenAsWait         = false,
+    wfiGenAsNop    = true,
     ucycleAccess   = CsrAccess.NONE
   )
 


### PR DESCRIPTION
This commit enables `ecall` instruction in `small` variant enabling it to run [Zephyr RTOS](http://github.com/zephyrproject-rtos/zephyr).

FPGA utilization verified on `tinyfpga_bx.lite` target in [Litex](https://github.com/enjoy-digital/litex): 4227 vs. 4273 LC.

Without `ecall` support:
```
Info: Device utilisation:
Info:            ICESTORM_LC:  4227/ 7680    55%
Info:           ICESTORM_RAM:    32/   32   100%
Info:                  SB_IO:    13/  256     5%
Info:                  SB_GB:     8/    8   100%
Info:           ICESTORM_PLL:     0/    2     0%
Info:            SB_WARMBOOT:     0/    1     0%
```
With `ecall` support:
```
Info: Device utilisation:
Info:            ICESTORM_LC:  4273/ 7680    55%
Info:           ICESTORM_RAM:    32/   32   100%
Info:                  SB_IO:    13/  256     5%
Info:                  SB_GB:     8/    8   100%
Info:           ICESTORM_PLL:     0/    2     0%
Info:            SB_WARMBOOT:     0/    1     0%
```