### PR TITLE
Murax on arty_a7: fix inferred memory type

### DIFF
--- a/scripts/Murax/arty_a7/make_vivado_project
+++ b/scripts/Murax/arty_a7/make_vivado_project
@@ -3,7 +3,7 @@
 #cannot rm build because it erase software images that the make file copy there
 #rm -rf ./build
 
-mkdir ./build
+mkdir -p ./build
 
 cd ./build
 vivado -mode batch -source ../make_vivado_project.tcl -notrace

--- a/scripts/Murax/arty_a7/soc_mmi.tcl
+++ b/scripts/Murax/arty_a7/soc_mmi.tcl
@@ -21,7 +21,7 @@ proc swap_bits { bit } {
 # open_run impl_1
 
 # Find all the RAMs, place in a list
-set rams [get_cells -hier -regexp {.*core/system_ram/.*} -filter {REF_NAME =~ RAMB36E1}]
+set rams [get_cells -hier -regexp {.*core/system_ram/.*} -filter {REF_NAME == RAMB36E1 || REF_NAME == RAMB18E1}]
 
 puts "[llength $rams] RAMs in total"
 foreach m $rams {puts $m}
@@ -89,7 +89,7 @@ set i 0
 foreach ram $rams {
     # Get the RAM location
     set loc_val [get_property LOC [get_cells $ram]]
-    regexp -- {(RAMB36_)([0-9XY]+)} $loc_val full ram_name loc_xy
+    regexp {(RAMB.+_)([0-9XY]+)} $loc_val full ram_name loc_xy
 
     set memi [dict create ram $ram loc $loc_xy]
 


### PR DESCRIPTION
My Vivado version (2018.3) infers `RAMB18E1`s instead of `RAMB36E1`s, which is probably more area-efficient (or maybe it's the same after optimization). But this breaks a TCL script that assumes the second case; after this patch, it should be compatible with both.