### PR TITLE
Update big endian instruction encoding

### DIFF
--- a/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
@@ -373,10 +373,9 @@ class IBusSimplePlugin(    resetVector : BigInt,
         fetchRsp.rsp := rspBuffer.output.payload
         fetchRsp.rsp.error.clearWhen(!rspBuffer.output.valid) //Avoid interference with instruction injection from the debug plugin
         if(bigEndian){
-          // inst(15 downto 0) should contain lower addressed parcel,
-          // and inst(31 downto 16) the higher addressed parcel
+          // instructions are stored in little endian byteorder
           fetchRsp.rsp.inst.allowOverride
-          fetchRsp.rsp.inst := rspBuffer.output.payload.inst.rotateLeft(16)
+          fetchRsp.rsp.inst := EndiannessSwap(rspBuffer.output.payload.inst)
         }
 
         val join = Stream(FetchRsp())


### PR DESCRIPTION
Between draft-20181101-ebe1ca4 and draft-20190622-6993896 of the
RISC-V Instruction Set Manual, the wording was changed from requiring
"natural endianness" of instruction parcels to require them to be
little endian.

Update the big endian instruction pipe to reflect the newer requirement.

Updated toolchains can be found here:
https://github.com/zeldin/riscv-binutils-gdb/commits/big-endian
https://github.com/zeldin/riscv-gcc/commits/big-endian