### PR TITLE
Distinguish between page faults from the MMU and access faults from PMP

### DIFF
--- a/src/main/scala/vexriscv/Services.scala
+++ b/src/main/scala/vexriscv/Services.scala
@@ -71,6 +71,7 @@ case class MemoryTranslatorCmd() extends Bundle{
 case class MemoryTranslatorRsp() extends Bundle{
   val physicalAddress = UInt(32 bits)
   val isIoAccess = Bool
+  val isPaging = Bool
   val allowRead, allowWrite, allowExecute = Bool
   val exception = Bool
   val refilling = Bool

--- a/src/main/scala/vexriscv/TestsWorkspace.scala
+++ b/src/main/scala/vexriscv/TestsWorkspace.scala
@@ -37,7 +37,7 @@ object TestsWorkspace {
           //            cmdForkPersistence = false,
           //            prediction = NONE,
           //            historyRamSizeLog2 = 10,
-          //            catchInstructionAccess = false,
+          //            catchAccessFault = false,
           //            compressedGen = false,
           //            busLatencyMin = 1,
           //            injectorStage = true
@@ -67,7 +67,7 @@ object TestsWorkspace {
 //          ).newTightlyCoupledPort(TightlyCoupledPortParameter("iBusTc", a => a(30 downto 28) === 0x0 && a(5))),
           //          new DBusSimplePlugin(
           //            catchAddressMisaligned = true,
-          //            catchInstructionAccess = false,
+          //            catchAccessFault = false,
           //            earlyInjection = false
           //          ),
           new DBusCachedPlugin(
@@ -78,9 +78,9 @@ object TestsWorkspace {
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchLoadStoreAccess  = true,
-              catchLoadStorePage      = true,
-              catchLoadStoreMisaligned    = true,
+              catchLoadStoreAccess = true,
+              catchLoadStorePage = true,
+              catchLoadStoreMisaligned = true,
               withLrSc = true
             ),
             //            memoryTranslatorPortConfig = null
@@ -131,7 +131,7 @@ object TestsWorkspace {
           new CsrPlugin(CsrPluginConfig.all(0x80000020l)),
           //          new CsrPlugin(//CsrPluginConfig.all2(0x80000020l).copy(ebreakGen = true)/*
           //             CsrPluginConfig(
-          //            catchInstructionPage = false,
+          //            catchIllegalAccess = false,
           //            mvendorid      = null,
           //            marchid        = null,
           //            mimpid         = null,

--- a/src/main/scala/vexriscv/TestsWorkspace.scala
+++ b/src/main/scala/vexriscv/TestsWorkspace.scala
@@ -37,7 +37,7 @@ object TestsWorkspace {
           //            cmdForkPersistence = false,
           //            prediction = NONE,
           //            historyRamSizeLog2 = 10,
-          //            catchAccessFault = false,
+          //            catchInstructionAccess = false,
           //            compressedGen = false,
           //            busLatencyMin = 1,
           //            injectorStage = true
@@ -54,8 +54,8 @@ object TestsWorkspace {
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
-              catchIllegalAccess = true,
-              catchAccessFault = true,
+              catchInstructionPage = true,
+              catchInstructionAccess = true,
               asyncTagMemory = false,
               twoCycleRam = false,
               twoCycleCache = true
@@ -67,7 +67,7 @@ object TestsWorkspace {
 //          ).newTightlyCoupledPort(TightlyCoupledPortParameter("iBusTc", a => a(30 downto 28) === 0x0 && a(5))),
           //          new DBusSimplePlugin(
           //            catchAddressMisaligned = true,
-          //            catchAccessFault = false,
+          //            catchInstructionAccess = false,
           //            earlyInjection = false
           //          ),
           new DBusCachedPlugin(
@@ -78,9 +78,9 @@ object TestsWorkspace {
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchAccessError  = true,
-              catchIllegal      = true,
-              catchUnaligned    = true,
+              catchLoadStoreAccess  = true,
+              catchLoadStorePage      = true,
+              catchLoadStoreMisaligned    = true,
               withLrSc = true
             ),
             //            memoryTranslatorPortConfig = null
@@ -131,7 +131,7 @@ object TestsWorkspace {
           new CsrPlugin(CsrPluginConfig.all(0x80000020l)),
           //          new CsrPlugin(//CsrPluginConfig.all2(0x80000020l).copy(ebreakGen = true)/*
           //             CsrPluginConfig(
-          //            catchIllegalAccess = false,
+          //            catchInstructionPage = false,
           //            mvendorid      = null,
           //            marchid        = null,
           //            mimpid         = null,

--- a/src/main/scala/vexriscv/demo/Briey.scala
+++ b/src/main/scala/vexriscv/demo/Briey.scala
@@ -53,7 +53,7 @@ object BrieyConfig{
         new PcManagerSimplePlugin(0x80000000l, false),
         //          new IBusSimplePlugin(
         //            interfaceKeepData = false,
-        //            catchInstructionAccess = true
+        //            catchAccessFault = true
         //          ),
         new IBusCachedPlugin(
           resetVector = 0x80000000l,
@@ -78,7 +78,7 @@ object BrieyConfig{
         ),
         //                    new DBusSimplePlugin(
         //                      catchAddressMisaligned = true,
-        //                      catchInstructionAccess = true
+        //                      catchAccessFault = true
         //                    ),
         new DBusCachedPlugin(
           config = new DataCacheConfig(
@@ -88,9 +88,9 @@ object BrieyConfig{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchLoadStoreAccess  = true,
-            catchLoadStorePage      = true,
-            catchLoadStoreMisaligned    = true
+            catchLoadStoreAccess = true,
+            catchLoadStorePage = true,
+            catchLoadStoreMisaligned = true
           ),
           memoryTranslatorPortConfig = null
           //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(

--- a/src/main/scala/vexriscv/demo/Briey.scala
+++ b/src/main/scala/vexriscv/demo/Briey.scala
@@ -53,7 +53,7 @@ object BrieyConfig{
         new PcManagerSimplePlugin(0x80000000l, false),
         //          new IBusSimplePlugin(
         //            interfaceKeepData = false,
-        //            catchAccessFault = true
+        //            catchInstructionAccess = true
         //          ),
         new IBusCachedPlugin(
           resetVector = 0x80000000l,
@@ -65,8 +65,8 @@ object BrieyConfig{
             addressWidth = 32,
             cpuDataWidth = 32,
             memDataWidth = 32,
-            catchIllegalAccess = true,
-            catchAccessFault = true,
+            catchInstructionPage = true,
+            catchInstructionAccess = true,
             asyncTagMemory = false,
             twoCycleRam = true,
             twoCycleCache = true
@@ -78,7 +78,7 @@ object BrieyConfig{
         ),
         //                    new DBusSimplePlugin(
         //                      catchAddressMisaligned = true,
-        //                      catchAccessFault = true
+        //                      catchInstructionAccess = true
         //                    ),
         new DBusCachedPlugin(
           config = new DataCacheConfig(
@@ -88,9 +88,9 @@ object BrieyConfig{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchAccessError  = true,
-            catchIllegal      = true,
-            catchUnaligned    = true
+            catchLoadStoreAccess  = true,
+            catchLoadStorePage      = true,
+            catchLoadStoreMisaligned    = true
           ),
           memoryTranslatorPortConfig = null
           //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(
@@ -130,7 +130,7 @@ object BrieyConfig{
         ),
         new CsrPlugin(
           config = CsrPluginConfig(
-            catchIllegalAccess = false,
+            catchInstructionPage = false,
             mvendorid      = null,
             marchid        = null,
             mimpid         = null,

--- a/src/main/scala/vexriscv/demo/FormalSimple.scala
+++ b/src/main/scala/vexriscv/demo/FormalSimple.scala
@@ -18,12 +18,12 @@ object FormalSimple extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = DYNAMIC_TARGET,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = true
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = true,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new DecoderSimplePlugin(
           catchIllegalInstruction = true,

--- a/src/main/scala/vexriscv/demo/GenCustomCsr.scala
+++ b/src/main/scala/vexriscv/demo/GenCustomCsr.scala
@@ -21,12 +21,12 @@ object GenCustomCsr extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new DecoderSimplePlugin(
           catchIllegalInstruction = false

--- a/src/main/scala/vexriscv/demo/GenCustomInterrupt.scala
+++ b/src/main/scala/vexriscv/demo/GenCustomInterrupt.scala
@@ -30,12 +30,12 @@ object GenCustomInterrupt extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new DecoderSimplePlugin(
           catchIllegalInstruction = false

--- a/src/main/scala/vexriscv/demo/GenCustomSimdAdd.scala
+++ b/src/main/scala/vexriscv/demo/GenCustomSimdAdd.scala
@@ -17,12 +17,12 @@ object GenCustomSimdAdd extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new DecoderSimplePlugin(
           catchIllegalInstruction = false

--- a/src/main/scala/vexriscv/demo/GenDeterministicVex.scala
+++ b/src/main/scala/vexriscv/demo/GenDeterministicVex.scala
@@ -16,12 +16,12 @@ object GenDeterministicVex extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = STATIC,
-          catchAccessFault = true,
+          catchInstructionAccess = true,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = true,
-          catchAccessFault = true,
+          catchInstructionAccess = true,
           earlyInjection = false
         ),
         new StaticMemoryTranslatorPlugin(

--- a/src/main/scala/vexriscv/demo/GenFull.scala
+++ b/src/main/scala/vexriscv/demo/GenFull.scala
@@ -39,9 +39,9 @@ object GenFull extends App{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchLoadStoreAccess  = true,
-            catchLoadStorePage      = true,
-            catchLoadStoreMisaligned    = true
+            catchLoadStoreAccess = true,
+            catchLoadStorePage = true,
+            catchLoadStoreMisaligned = true
           ),
           memoryTranslatorPortConfig = MmuPortConfig(
             portTlbSize = 6

--- a/src/main/scala/vexriscv/demo/GenFull.scala
+++ b/src/main/scala/vexriscv/demo/GenFull.scala
@@ -21,8 +21,8 @@ object GenFull extends App{
             addressWidth = 32,
             cpuDataWidth = 32,
             memDataWidth = 32,
-            catchIllegalAccess = true,
-            catchAccessFault = true,
+            catchInstructionPage = true,
+            catchInstructionAccess = true,
             asyncTagMemory = false,
             twoCycleRam = true,
             twoCycleCache = true
@@ -39,9 +39,9 @@ object GenFull extends App{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchAccessError  = true,
-            catchIllegal      = true,
-            catchUnaligned    = true
+            catchLoadStoreAccess  = true,
+            catchLoadStorePage      = true,
+            catchLoadStoreMisaligned    = true
           ),
           memoryTranslatorPortConfig = MmuPortConfig(
             portTlbSize = 6

--- a/src/main/scala/vexriscv/demo/GenFullNoMmu.scala
+++ b/src/main/scala/vexriscv/demo/GenFullNoMmu.scala
@@ -40,9 +40,9 @@ object GenFullNoMmu extends App{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchLoadStoreAccess  = true,
-            catchLoadStorePage      = true,
-            catchLoadStoreMisaligned    = true
+            catchLoadStoreAccess = true,
+            catchLoadStorePage = true,
+            catchLoadStoreMisaligned = true
           )
         ),
         new StaticMemoryTranslatorPlugin(

--- a/src/main/scala/vexriscv/demo/GenFullNoMmu.scala
+++ b/src/main/scala/vexriscv/demo/GenFullNoMmu.scala
@@ -25,8 +25,8 @@ object GenFullNoMmu extends App{
             addressWidth = 32,
             cpuDataWidth = 32,
             memDataWidth = 32,
-            catchIllegalAccess = true,
-            catchAccessFault = true,
+            catchInstructionPage = true,
+            catchInstructionAccess = true,
             asyncTagMemory = false,
             twoCycleRam = true,
             twoCycleCache = true
@@ -40,9 +40,9 @@ object GenFullNoMmu extends App{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchAccessError  = true,
-            catchIllegal      = true,
-            catchUnaligned    = true
+            catchLoadStoreAccess  = true,
+            catchLoadStorePage      = true,
+            catchLoadStoreMisaligned    = true
           )
         ),
         new StaticMemoryTranslatorPlugin(

--- a/src/main/scala/vexriscv/demo/GenFullNoMmuMaxPerf.scala
+++ b/src/main/scala/vexriscv/demo/GenFullNoMmuMaxPerf.scala
@@ -26,8 +26,8 @@ object GenFullNoMmuMaxPerf extends App{
             addressWidth = 32,
             cpuDataWidth = 32,
             memDataWidth = 32,
-            catchIllegalAccess = true,
-            catchAccessFault = true,
+            catchInstructionPage = true,
+            catchInstructionAccess = true,
             asyncTagMemory = false,
             twoCycleRam = false,
             twoCycleCache = true
@@ -41,9 +41,9 @@ object GenFullNoMmuMaxPerf extends App{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchAccessError  = true,
-            catchIllegal      = true,
-            catchUnaligned    = true
+            catchLoadStoreAccess  = true,
+            catchLoadStorePage      = true,
+            catchLoadStoreMisaligned    = true
           )
         ),
         new StaticMemoryTranslatorPlugin(

--- a/src/main/scala/vexriscv/demo/GenFullNoMmuMaxPerf.scala
+++ b/src/main/scala/vexriscv/demo/GenFullNoMmuMaxPerf.scala
@@ -41,9 +41,9 @@ object GenFullNoMmuMaxPerf extends App{
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchLoadStoreAccess  = true,
-            catchLoadStorePage      = true,
-            catchLoadStoreMisaligned    = true
+            catchLoadStoreAccess = true,
+            catchLoadStorePage = true,
+            catchLoadStoreMisaligned = true
           )
         ),
         new StaticMemoryTranslatorPlugin(

--- a/src/main/scala/vexriscv/demo/GenFullNoMmuNoCache.scala
+++ b/src/main/scala/vexriscv/demo/GenFullNoMmuNoCache.scala
@@ -17,12 +17,12 @@ object GenFullNoMmuNoCache extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = STATIC,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new DecoderSimplePlugin(
           catchIllegalInstruction = true

--- a/src/main/scala/vexriscv/demo/GenFullNoMmuNoCacheSimpleMul.scala
+++ b/src/main/scala/vexriscv/demo/GenFullNoMmuNoCacheSimpleMul.scala
@@ -17,12 +17,12 @@ object GenFullNoMmuNoCacheSimpleMul extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = STATIC,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new DecoderSimplePlugin(
           catchIllegalInstruction = true

--- a/src/main/scala/vexriscv/demo/GenMicroNoCsr.scala
+++ b/src/main/scala/vexriscv/demo/GenMicroNoCsr.scala
@@ -18,12 +18,12 @@ object GenMicroNoCsr extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           earlyInjection = false
         ),
         new DecoderSimplePlugin(

--- a/src/main/scala/vexriscv/demo/GenNoCacheNoMmuMaxPerf.scala
+++ b/src/main/scala/vexriscv/demo/GenNoCacheNoMmuMaxPerf.scala
@@ -18,12 +18,12 @@ object GenNoCacheNoMmuMaxPerf extends App{
           cmdForkPersistence = false,
           prediction = DYNAMIC_TARGET,
           historyRamSizeLog2 = 8,
-          catchAccessFault = true,
+          catchInstructionAccess = true,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = true,
-          catchAccessFault = true,
+          catchInstructionAccess = true,
           earlyInjection = false
         ),
         new StaticMemoryTranslatorPlugin(

--- a/src/main/scala/vexriscv/demo/GenSecure.scala
+++ b/src/main/scala/vexriscv/demo/GenSecure.scala
@@ -35,8 +35,8 @@ object GenSecure extends App {
             cpuDataWidth     = 32,
             memDataWidth     = 32,
             catchLoadStoreAccess = true,
-            catchLoadStorePage     = true,
-            catchLoadStoreMisaligned   = true
+            catchLoadStorePage = true,
+            catchLoadStoreMisaligned = true
           )
         ),
         new PmpPlugin(

--- a/src/main/scala/vexriscv/demo/GenSecure.scala
+++ b/src/main/scala/vexriscv/demo/GenSecure.scala
@@ -19,8 +19,8 @@ object GenSecure extends App {
             addressWidth = 32,
             cpuDataWidth = 32,
             memDataWidth = 32,
-            catchIllegalAccess = true,
-            catchAccessFault = true,
+            catchInstructionPage = true,
+            catchInstructionAccess = true,
             asyncTagMemory = false,
             twoCycleRam = true,
             twoCycleCache = true
@@ -34,9 +34,9 @@ object GenSecure extends App {
             addressWidth     = 32,
             cpuDataWidth     = 32,
             memDataWidth     = 32,
-            catchAccessError = true,
-            catchIllegal     = true,
-            catchUnaligned   = true
+            catchLoadStoreAccess = true,
+            catchLoadStorePage     = true,
+            catchLoadStoreMisaligned   = true
           )
         ),
         new PmpPlugin(

--- a/src/main/scala/vexriscv/demo/GenSmallAndProductive.scala
+++ b/src/main/scala/vexriscv/demo/GenSmallAndProductive.scala
@@ -16,12 +16,12 @@ object GenSmallAndProductive extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new CsrPlugin(CsrPluginConfig.smallest),
         new DecoderSimplePlugin(

--- a/src/main/scala/vexriscv/demo/GenSmallAndProductiveCfu.scala
+++ b/src/main/scala/vexriscv/demo/GenSmallAndProductiveCfu.scala
@@ -16,12 +16,12 @@ object GenSmallAndProductiveCfu extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new CsrPlugin(CsrPluginConfig.smallest),
         new DecoderSimplePlugin(

--- a/src/main/scala/vexriscv/demo/GenSmallAndProductiveICache.scala
+++ b/src/main/scala/vexriscv/demo/GenSmallAndProductiveICache.scala
@@ -24,8 +24,8 @@ object GenSmallAndProductiveICache extends App{
             addressWidth = 32,
             cpuDataWidth = 32,
             memDataWidth = 32,
-            catchIllegalAccess = false,
-            catchAccessFault = false,
+            catchInstructionPage = false,
+            catchInstructionAccess = false,
             asyncTagMemory = false,
             twoCycleRam = false,
             twoCycleCache = true
@@ -33,7 +33,7 @@ object GenSmallAndProductiveICache extends App{
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new CsrPlugin(CsrPluginConfig.smallest),
         new DecoderSimplePlugin(

--- a/src/main/scala/vexriscv/demo/GenSmallest.scala
+++ b/src/main/scala/vexriscv/demo/GenSmallest.scala
@@ -16,12 +16,12 @@ object GenSmallest extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false
+          catchInstructionAccess = false
         ),
         new CsrPlugin(CsrPluginConfig.smallest),
         new DecoderSimplePlugin(

--- a/src/main/scala/vexriscv/demo/GenSmallestNoCsr.scala
+++ b/src/main/scala/vexriscv/demo/GenSmallestNoCsr.scala
@@ -21,12 +21,12 @@ object GenSmallestNoCsr extends App{
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           compressedGen = false
         ),
         new DBusSimplePlugin(
           catchAddressMisaligned = false,
-          catchAccessFault = false,
+          catchInstructionAccess = false,
           earlyInjection = false
         ),
         new DecoderSimplePlugin(

--- a/src/main/scala/vexriscv/demo/Linux.scala
+++ b/src/main/scala/vexriscv/demo/Linux.scala
@@ -144,7 +144,7 @@ object LinuxGen {
 //          cmdForkPersistence = false,
 //          prediction = DYNAMIC_TARGET,
 //          historyRamSizeLog2 = 10,
-//          catchInstructionAccess = true,
+//          catchAccessFault = true,
 //          compressedGen = true,
 //          busLatencyMin = 1,
 //          injectorStage = true,
@@ -180,7 +180,7 @@ object LinuxGen {
         //          ).newTightlyCoupledPort(TightlyCoupledPortParameter("iBusTc", a => a(30 downto 28) === 0x0 && a(5))),
 //        new DBusSimplePlugin(
 //          catchAddressMisaligned = true,
-//          catchInstructionAccess = true,
+//          catchAccessFault = true,
 //          earlyInjection = false,
 //          withLrSc = true,
 //          memoryTranslatorPortConfig = withMmu generate MmuPortConfig(
@@ -198,9 +198,9 @@ object LinuxGen {
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchLoadStoreAccess  = true,
-            catchLoadStorePage      = true,
-            catchLoadStoreMisaligned    = true,
+            catchLoadStoreAccess = true,
+            catchLoadStorePage = true,
+            catchLoadStoreMisaligned = true,
             withLrSc = true,
             withAmo = true
 //          )
@@ -251,7 +251,7 @@ object LinuxGen {
         new CsrPlugin(CsrPluginConfig.linuxMinimal(0x80000020l).copy(ebreakGen = false)),
         //          new CsrPlugin(//CsrPluginConfig.all2(0x80000020l).copy(ebreakGen = true)/*
         //             CsrPluginConfig(
-        //            catchInstructionPage = false,
+        //            catchIllegalAccess = false,
         //            mvendorid      = null,
         //            marchid        = null,
         //            mimpid         = null,

--- a/src/main/scala/vexriscv/demo/Linux.scala
+++ b/src/main/scala/vexriscv/demo/Linux.scala
@@ -144,7 +144,7 @@ object LinuxGen {
 //          cmdForkPersistence = false,
 //          prediction = DYNAMIC_TARGET,
 //          historyRamSizeLog2 = 10,
-//          catchAccessFault = true,
+//          catchInstructionAccess = true,
 //          compressedGen = true,
 //          busLatencyMin = 1,
 //          injectorStage = true,
@@ -166,8 +166,8 @@ object LinuxGen {
             addressWidth = 32,
             cpuDataWidth = 32,
             memDataWidth = 32,
-            catchIllegalAccess = true,
-            catchAccessFault = true,
+            catchInstructionPage = true,
+            catchInstructionAccess = true,
             asyncTagMemory = false,
             twoCycleRam = false,
             twoCycleCache = true
@@ -180,7 +180,7 @@ object LinuxGen {
         //          ).newTightlyCoupledPort(TightlyCoupledPortParameter("iBusTc", a => a(30 downto 28) === 0x0 && a(5))),
 //        new DBusSimplePlugin(
 //          catchAddressMisaligned = true,
-//          catchAccessFault = true,
+//          catchInstructionAccess = true,
 //          earlyInjection = false,
 //          withLrSc = true,
 //          memoryTranslatorPortConfig = withMmu generate MmuPortConfig(
@@ -198,9 +198,9 @@ object LinuxGen {
             addressWidth      = 32,
             cpuDataWidth      = 32,
             memDataWidth      = 32,
-            catchAccessError  = true,
-            catchIllegal      = true,
-            catchUnaligned    = true,
+            catchLoadStoreAccess  = true,
+            catchLoadStorePage      = true,
+            catchLoadStoreMisaligned    = true,
             withLrSc = true,
             withAmo = true
 //          )
@@ -251,7 +251,7 @@ object LinuxGen {
         new CsrPlugin(CsrPluginConfig.linuxMinimal(0x80000020l).copy(ebreakGen = false)),
         //          new CsrPlugin(//CsrPluginConfig.all2(0x80000020l).copy(ebreakGen = true)/*
         //             CsrPluginConfig(
-        //            catchIllegalAccess = false,
+        //            catchInstructionPage = false,
         //            mvendorid      = null,
         //            marchid        = null,
         //            mimpid         = null,

--- a/src/main/scala/vexriscv/demo/Murax.scala
+++ b/src/main/scala/vexriscv/demo/Murax.scala
@@ -74,13 +74,13 @@ object MuraxConfig{
         cmdForkOnSecondStage = true,
         cmdForkPersistence = withXip, //Required by the Xip controller
         prediction = NONE,
-        catchAccessFault = false,
+        catchInstructionAccess = false,
         compressedGen = false,
         bigEndian = bigEndian
       ),
       new DBusSimplePlugin(
         catchAddressMisaligned = false,
-        catchAccessFault = false,
+        catchInstructionAccess = false,
         earlyInjection = false,
         bigEndian = bigEndian
       ),
@@ -460,7 +460,7 @@ object MuraxDhrystoneReadyMulDivStatic{
         cmdForkOnSecondStage = true,
         cmdForkPersistence = false,
         prediction = STATIC,
-        catchAccessFault = false,
+        catchInstructionAccess = false,
         compressedGen = false
       )
       config.cpuPlugins.remove(config.cpuPlugins.indexWhere(_.isInstanceOf[LightShifterPlugin]))

--- a/src/main/scala/vexriscv/demo/VexRiscvAhbLite3.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAhbLite3.scala
@@ -31,12 +31,12 @@ object VexRiscvAhbLite3{
             cmdForkOnSecondStage = false,
             cmdForkPersistence = true,
             prediction = STATIC,
-            catchAccessFault = false,
+            catchInstructionAccess = false,
             compressedGen = false
           ),
           new DBusSimplePlugin(
             catchAddressMisaligned = false,
-            catchAccessFault = false
+            catchInstructionAccess = false
           ),
 //          new IBusCachedPlugin(
 //            config = InstructionCacheConfig(
@@ -46,8 +46,8 @@ object VexRiscvAhbLite3{
 //              addressWidth = 32,
 //              cpuDataWidth = 32,
 //              memDataWidth = 32,
-//              catchIllegalAccess = true,
-//              catchAccessFault = true,
+//              catchInstructionPage = true,
+//              catchInstructionAccess = true,
 //              catchMemoryTranslationMiss = true,
 //              asyncTagMemory = false,
 //              twoCycleRam = true
@@ -65,9 +65,9 @@ object VexRiscvAhbLite3{
 //              addressWidth      = 32,
 //              cpuDataWidth      = 32,
 //              memDataWidth      = 32,
-//              catchAccessError  = true,
-//              catchIllegal      = true,
-//              catchUnaligned    = true,
+//              catchLoadStoreAccess  = true,
+//              catchLoadStorePage      = true,
+//              catchLoadStoreMisaligned    = true,
 //              catchMemoryTranslationMiss = true
 //            ),
 //            memoryTranslatorPortConfig = null
@@ -109,7 +109,7 @@ object VexRiscvAhbLite3{
           ),
           new CsrPlugin(
             config = CsrPluginConfig(
-              catchIllegalAccess = false,
+              catchInstructionPage = false,
               mvendorid      = null,
               marchid        = null,
               mimpid         = null,

--- a/src/main/scala/vexriscv/demo/VexRiscvAhbLite3.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAhbLite3.scala
@@ -46,8 +46,8 @@ object VexRiscvAhbLite3{
 //              addressWidth = 32,
 //              cpuDataWidth = 32,
 //              memDataWidth = 32,
-//              catchInstructionPage = true,
-//              catchInstructionAccess = true,
+//              catchIllegalAccess = true,
+//              catchAccessFault = true,
 //              catchMemoryTranslationMiss = true,
 //              asyncTagMemory = false,
 //              twoCycleRam = true
@@ -65,9 +65,9 @@ object VexRiscvAhbLite3{
 //              addressWidth      = 32,
 //              cpuDataWidth      = 32,
 //              memDataWidth      = 32,
-//              catchLoadStoreAccess  = true,
-//              catchLoadStorePage      = true,
-//              catchLoadStoreMisaligned    = true,
+//              catchAccessError  = true,
+//              catchIllegal      = true,
+//              catchUnaligned    = true,
 //              catchMemoryTranslationMiss = true
 //            ),
 //            memoryTranslatorPortConfig = null

--- a/src/main/scala/vexriscv/demo/VexRiscvAvalonForSim.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAvalonForSim.scala
@@ -31,12 +31,12 @@ object VexRiscvAvalonForSim{
             cmdForkOnSecondStage = false,
             cmdForkPersistence = false,
             prediction = STATIC,
-            catchAccessFault = false,
+            catchInstructionAccess = false,
             compressedGen = false
           ),
           new DBusSimplePlugin(
             catchAddressMisaligned = false,
-            catchAccessFault = false
+            catchInstructionAccess = false
           ),*/
           new IBusCachedPlugin(
             config = InstructionCacheConfig(
@@ -46,8 +46,8 @@ object VexRiscvAvalonForSim{
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
-              catchIllegalAccess = true,
-              catchAccessFault = true,
+              catchInstructionPage = true,
+              catchInstructionAccess = true,
               asyncTagMemory = false,
               twoCycleRam = true
             )
@@ -64,9 +64,9 @@ object VexRiscvAvalonForSim{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchAccessError  = true,
-              catchIllegal      = true,
-              catchUnaligned    = true
+              catchLoadStoreAccess  = true,
+              catchLoadStorePage      = true,
+              catchLoadStoreMisaligned    = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(
@@ -107,7 +107,7 @@ object VexRiscvAvalonForSim{
           ),
           new CsrPlugin(
             config = CsrPluginConfig(
-              catchIllegalAccess = false,
+              catchInstructionPage = false,
               mvendorid      = null,
               marchid        = null,
               mimpid         = null,

--- a/src/main/scala/vexriscv/demo/VexRiscvAvalonForSim.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAvalonForSim.scala
@@ -64,9 +64,9 @@ object VexRiscvAvalonForSim{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchLoadStoreAccess  = true,
-              catchLoadStorePage      = true,
-              catchLoadStoreMisaligned    = true
+              catchLoadStoreAccess = true,
+              catchLoadStorePage = true,
+              catchLoadStoreMisaligned = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(

--- a/src/main/scala/vexriscv/demo/VexRiscvAvalonWithIntegratedJtag.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAvalonWithIntegratedJtag.scala
@@ -27,11 +27,11 @@ object VexRiscvAvalonWithIntegratedJtag{
           new PcManagerSimplePlugin(0x00000000l, false),
 //          new IBusSimplePlugin(
 //            interfaceKeepData = false,
-//            catchInstructionAccess = false
+//            catchAccessFault = false
 //          ),
 //          new DBusSimplePlugin(
 //            catchAddressMisaligned = false,
-//            catchInstructionAccess = false
+//            catchAccessFault = false
 //          ),
           new IBusCachedPlugin(
             prediction = STATIC,
@@ -61,9 +61,9 @@ object VexRiscvAvalonWithIntegratedJtag{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchLoadStoreAccess  = true,
-              catchLoadStorePage      = true,
-              catchLoadStoreMisaligned    = true
+              catchLoadStoreAccess = true,
+              catchLoadStorePage = true,
+              catchLoadStoreMisaligned = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(

--- a/src/main/scala/vexriscv/demo/VexRiscvAvalonWithIntegratedJtag.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAvalonWithIntegratedJtag.scala
@@ -27,11 +27,11 @@ object VexRiscvAvalonWithIntegratedJtag{
           new PcManagerSimplePlugin(0x00000000l, false),
 //          new IBusSimplePlugin(
 //            interfaceKeepData = false,
-//            catchAccessFault = false
+//            catchInstructionAccess = false
 //          ),
 //          new DBusSimplePlugin(
 //            catchAddressMisaligned = false,
-//            catchAccessFault = false
+//            catchInstructionAccess = false
 //          ),
           new IBusCachedPlugin(
             prediction = STATIC,
@@ -42,8 +42,8 @@ object VexRiscvAvalonWithIntegratedJtag{
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
-              catchIllegalAccess = true,
-              catchAccessFault = true,
+              catchInstructionPage = true,
+              catchInstructionAccess = true,
               asyncTagMemory = false,
               twoCycleRam = true,
               twoCycleCache = true
@@ -61,9 +61,9 @@ object VexRiscvAvalonWithIntegratedJtag{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchAccessError  = true,
-              catchIllegal      = true,
-              catchUnaligned    = true
+              catchLoadStoreAccess  = true,
+              catchLoadStorePage      = true,
+              catchLoadStoreMisaligned    = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(
@@ -104,7 +104,7 @@ object VexRiscvAvalonWithIntegratedJtag{
           ),
           new CsrPlugin(
             config = CsrPluginConfig(
-              catchIllegalAccess = false,
+              catchInstructionPage = false,
               mvendorid      = null,
               marchid        = null,
               mimpid         = null,

--- a/src/main/scala/vexriscv/demo/VexRiscvAxi4WithIntegratedJtag.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAxi4WithIntegratedJtag.scala
@@ -28,11 +28,11 @@ object VexRiscvAxi4WithIntegratedJtag{
           new PcManagerSimplePlugin(0x00000000l, false),
 //          new IBusSimplePlugin(
 //            interfaceKeepData = false,
-//            catchAccessFault = false
+//            catchInstructionAccess = false
 //          ),
 //          new DBusSimplePlugin(
 //            catchAddressMisaligned = false,
-//            catchAccessFault = false
+//            catchInstructionAccess = false
 //          ),
           new IBusCachedPlugin(
             prediction = STATIC,
@@ -43,8 +43,8 @@ object VexRiscvAxi4WithIntegratedJtag{
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
-              catchIllegalAccess = true,
-              catchAccessFault = true,
+              catchInstructionPage = true,
+              catchInstructionAccess = true,
               asyncTagMemory = false,
               twoCycleRam = true,
               twoCycleCache = true
@@ -62,9 +62,9 @@ object VexRiscvAxi4WithIntegratedJtag{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchAccessError  = true,
-              catchIllegal      = true,
-              catchUnaligned    = true
+              catchLoadStoreAccess  = true,
+              catchLoadStorePage      = true,
+              catchLoadStoreMisaligned    = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(
@@ -105,7 +105,7 @@ object VexRiscvAxi4WithIntegratedJtag{
           ),
           new CsrPlugin(
             config = CsrPluginConfig(
-              catchIllegalAccess = false,
+              catchInstructionPage = false,
               mvendorid      = null,
               marchid        = null,
               mimpid         = null,

--- a/src/main/scala/vexriscv/demo/VexRiscvAxi4WithIntegratedJtag.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAxi4WithIntegratedJtag.scala
@@ -28,11 +28,11 @@ object VexRiscvAxi4WithIntegratedJtag{
           new PcManagerSimplePlugin(0x00000000l, false),
 //          new IBusSimplePlugin(
 //            interfaceKeepData = false,
-//            catchInstructionAccess = false
+//            catchAccessFault = false
 //          ),
 //          new DBusSimplePlugin(
 //            catchAddressMisaligned = false,
-//            catchInstructionAccess = false
+//            catchAccessFault = false
 //          ),
           new IBusCachedPlugin(
             prediction = STATIC,
@@ -62,9 +62,9 @@ object VexRiscvAxi4WithIntegratedJtag{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchLoadStoreAccess  = true,
-              catchLoadStorePage      = true,
-              catchLoadStoreMisaligned    = true
+              catchLoadStoreAccess = true,
+              catchLoadStorePage = true,
+              catchLoadStoreMisaligned = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(

--- a/src/main/scala/vexriscv/demo/VexRiscvCachedWishboneForSim.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvCachedWishboneForSim.scala
@@ -30,7 +30,7 @@ object VexRiscvCachedWishboneForSim{
 //          ),
 //          new DBusSimplePlugin(
 //            catchAddressMisaligned = false,
-//            catchAccessFault = false
+//            catchInstructionAccess = false
 //          ),
           new IBusCachedPlugin(
             resetVector = 0x80000000l,
@@ -42,8 +42,8 @@ object VexRiscvCachedWishboneForSim{
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
-              catchIllegalAccess = true,
-              catchAccessFault = true,
+              catchInstructionPage = true,
+              catchInstructionAccess = true,
               asyncTagMemory = false,
               twoCycleRam = true
             )
@@ -60,9 +60,9 @@ object VexRiscvCachedWishboneForSim{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchAccessError  = true,
-              catchIllegal      = true,
-              catchUnaligned    = true
+              catchLoadStoreAccess  = true,
+              catchLoadStorePage      = true,
+              catchLoadStoreMisaligned    = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(

--- a/src/main/scala/vexriscv/demo/VexRiscvCachedWishboneForSim.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvCachedWishboneForSim.scala
@@ -30,7 +30,7 @@ object VexRiscvCachedWishboneForSim{
 //          ),
 //          new DBusSimplePlugin(
 //            catchAddressMisaligned = false,
-//            catchInstructionAccess = false
+//            catchAccessFault = false
 //          ),
           new IBusCachedPlugin(
             resetVector = 0x80000000l,
@@ -60,9 +60,9 @@ object VexRiscvCachedWishboneForSim{
               addressWidth      = 32,
               cpuDataWidth      = 32,
               memDataWidth      = 32,
-              catchLoadStoreAccess  = true,
-              catchLoadStorePage      = true,
-              catchLoadStoreMisaligned    = true
+              catchLoadStoreAccess = true,
+              catchLoadStorePage = true,
+              catchLoadStoreMisaligned = true
             ),
             memoryTranslatorPortConfig = null
             //            memoryTranslatorPortConfig = MemoryTranslatorPortConfig(

--- a/src/main/scala/vexriscv/ip/InstructionCache.scala
+++ b/src/main/scala/vexriscv/ip/InstructionCache.scala
@@ -17,8 +17,8 @@ case class InstructionCacheConfig( cacheSize : Int,
                                    addressWidth : Int,
                                    cpuDataWidth : Int,
                                    memDataWidth : Int,
-                                   catchIllegalAccess : Boolean,
-                                   catchAccessFault : Boolean,
+                                   catchInstructionPage : Boolean,
+                                   catchInstructionAccess : Boolean,
                                    asyncTagMemory : Boolean,
                                    twoCycleCache : Boolean = true,
                                    twoCycleRam : Boolean = false,
@@ -28,7 +28,7 @@ case class InstructionCacheConfig( cacheSize : Int,
   assert(!(twoCycleRam && !twoCycleCache))
 
   def burstSize = bytePerLine*8/memDataWidth
-  def catchSomething = catchAccessFault || catchIllegalAccess
+  def catchSomething = catchInstructionAccess || catchInstructionPage
 
   def getAxi4Config() = Axi4Config(
     addressWidth = addressWidth,

--- a/src/main/scala/vexriscv/plugin/DBusCachedPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusCachedPlugin.scala
@@ -269,16 +269,16 @@ class DBusCachedPlugin(val config : DataCacheConfig,
 
 
       when(arbitration.isValid && input(MEMORY_ENABLE)) {
-        if (catchAccessError) when(cache.io.cpu.writeBack.accessError) {
+        if (catchLoadStoreAccess) when(cache.io.cpu.writeBack.accessError) {
           exceptionBus.valid := True
           exceptionBus.code := (input(MEMORY_WR) ? U(7) | U(5)).resized
         }
 
-        if (catchUnaligned) when(cache.io.cpu.writeBack.unalignedAccess) {
+        if (catchLoadStoreMisaligned) when(cache.io.cpu.writeBack.unalignedAccess) {
           exceptionBus.valid := True
           exceptionBus.code := (input(MEMORY_WR) ? U(6) | U(4)).resized
         }
-        if(catchIllegal) when (cache.io.cpu.writeBack.mmuException) {
+        if(catchLoadStorePage) when (cache.io.cpu.writeBack.mmuException) {
           exceptionBus.valid := True
           exceptionBus.code := (input(MEMORY_WR) ? U(15) | U(13)).resized
         }

--- a/src/main/scala/vexriscv/plugin/IBusCachedPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusCachedPlugin.scala
@@ -218,7 +218,7 @@ class IBusCachedPlugin(resetVector : BigInt = 0x80000000l,
           redoFetch := True
         }
 
-        if(catchIllegalAccess) when(cacheRsp.isValid && cacheRsp.mmuException && !issueDetected) {
+        if(catchInstructionPage) when(cacheRsp.isValid && cacheRsp.mmuException && !issueDetected) {
           issueDetected \= True
           decodeExceptionPort.valid := iBusRsp.readyForError
           decodeExceptionPort.code := 12
@@ -230,7 +230,7 @@ class IBusCachedPlugin(resetVector : BigInt = 0x80000000l,
           redoFetch := True
         }
 
-        if(catchAccessFault) when(cacheRsp.isValid && cacheRsp.error && !issueDetected) {
+        if(catchInstructionAccess) when(cacheRsp.isValid && cacheRsp.error && !issueDetected) {
           issueDetected \= True
           decodeExceptionPort.valid := iBusRsp.readyForError
           decodeExceptionPort.code := 1

--- a/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
@@ -222,7 +222,7 @@ case class IBusSimpleBus(plugin: IBusSimplePlugin) extends Bundle with IMasterSl
 class IBusSimplePlugin(    resetVector : BigInt,
                        val cmdForkOnSecondStage : Boolean,
                        val cmdForkPersistence : Boolean,
-                       val catchAccessFault : Boolean = false,
+                       val catchInstructionAccess : Boolean = false,
                            prediction : BranchPrediction = NONE,
                            historyRamSizeLog2 : Int = 10,
                            keepPcPlus4 : Boolean = false,
@@ -253,7 +253,7 @@ class IBusSimplePlugin(    resetVector : BigInt,
 
   var iBus : IBusSimpleBus = null
   var decodeExceptionPort : Flow[ExceptionCause] = null
-  val catchSomething = memoryTranslatorPortConfig != null || catchAccessFault
+  val catchSomething = memoryTranslatorPortConfig != null || catchInstructionAccess
   var mmuBus : MemoryTranslatorBus = null
 
 //  if(rspHoldValue) assert(busLatencyMin <= 1)
@@ -397,7 +397,7 @@ class IBusSimplePlugin(    resetVector : BigInt,
           decodeExceptionPort.code.assignDontCare()
           decodeExceptionPort.badAddr := join.pc(31 downto 2) @@ U"00"
 
-          if(catchAccessFault) when(join.valid && join.rsp.error){
+          if(catchInstructionAccess) when(join.valid && join.rsp.error){
             decodeExceptionPort.code  := 1
             exceptionDetected := True
           }

--- a/src/main/scala/vexriscv/plugin/MmuPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/MmuPlugin.scala
@@ -127,6 +127,7 @@ class MmuPlugin(ioRange : UInt => Bool,
           port.bus.rsp.allowExecute := cacheLine.allowExecute
           port.bus.rsp.exception := cacheHit && (cacheLine.exception || cacheLine.allowUser && privilegeService.isSupervisor() && !csr.status.sum || !cacheLine.allowUser && privilegeService.isUser())
           port.bus.rsp.refilling := !cacheHit
+          port.bus.rsp.isPaging := True
         } otherwise {
           port.bus.rsp.physicalAddress := port.bus.cmd.virtualAddress
           port.bus.rsp.allowRead := True
@@ -134,6 +135,7 @@ class MmuPlugin(ioRange : UInt => Bool,
           port.bus.rsp.allowExecute := True
           port.bus.rsp.exception := False
           port.bus.rsp.refilling := False
+          port.bus.rsp.isPaging := False
         }
         port.bus.rsp.isIoAccess := ioRange(port.bus.rsp.physicalAddress)
 

--- a/src/main/scala/vexriscv/plugin/PmpPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/PmpPlugin.scala
@@ -188,10 +188,10 @@ class PmpPlugin(regions : Int, ioRange : UInt => Bool) extends Plugin[VexRiscv] 
         port.bus.rsp.physicalAddress := address
 
         // Only the first matching PMP region applies.
-        val hits = pmps.map(pmp => pmp.region.valid && 
-                                   pmp.region.start <= address && 
-                                   pmp.region.end > address &&
-                                  (pmp.region.l || ~privilegeService.isMachine()))
+        val hits = pmps.map(pmp => pmp.region.valid &
+                                   pmp.region.start <= address &
+                                   pmp.region.end > address &
+                                  (pmp.region.l | ~privilegeService.isMachine()))
 
         // M-mode has full access by default, others have none.
         when(CountOne(hits) === 0) {
@@ -205,6 +205,7 @@ class PmpPlugin(regions : Int, ioRange : UInt => Bool) extends Plugin[VexRiscv] 
         }
 
         port.bus.rsp.isIoAccess := ioRange(port.bus.rsp.physicalAddress)
+        port.bus.rsp.isPaging := False
         port.bus.rsp.exception := False
         port.bus.rsp.refilling := False
         port.bus.busy := False

--- a/src/test/scala/vexriscv/TestIndividualFeatures.scala
+++ b/src/test/scala/vexriscv/TestIndividualFeatures.scala
@@ -341,7 +341,7 @@ class IBusDimension(rvcRate : Double) extends VexRiscvDimension("IBus") {
           cmdForkOnSecondStage = cmdForkOnSecondStage,
           cmdForkPersistence = cmdForkPersistence,
           prediction = prediction,
-          catchAccessFault = catchAll,
+          catchInstructionAccess = catchAll,
           compressedGen = compressed,
           busLatencyMin = latency,
           injectorStage = injectorStage,
@@ -382,8 +382,8 @@ class IBusDimension(rvcRate : Double) extends VexRiscvDimension("IBus") {
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
-              catchIllegalAccess = catchAll,
-              catchAccessFault = catchAll,
+              catchInstructionPage = catchAll,
+              catchInstructionAccess = catchAll,
               asyncTagMemory = false,
               twoCycleRam = twoCycleRam,
               twoCycleCache = twoCycleCache
@@ -419,7 +419,7 @@ class DBusDimension extends VexRiscvDimension("DBus") {
         override def testParam = "DBUS=SIMPLE " + (if(withLrSc) "LRSC=yes " else "")
         override def applyOn(config: VexRiscvConfig): Unit = config.plugins += new DBusSimplePlugin(
           catchAddressMisaligned = catchAll,
-          catchAccessFault = catchAll,
+          catchInstructionAccess = catchAll,
           earlyInjection = earlyInjection,
           memoryTranslatorPortConfig = mmuConfig,
           withLrSc = withLrSc
@@ -452,9 +452,9 @@ class DBusDimension extends VexRiscvDimension("DBus") {
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
-              catchAccessError = catchAll,
-              catchIllegal = catchAll,
-              catchUnaligned = catchAll,
+              catchLoadStoreAccess = catchAll,
+              catchLoadStorePage = catchAll,
+              catchLoadStoreMisaligned = catchAll,
               withLrSc = withLrSc,
               withAmo = withAmo,
               earlyWaysHits = earlyWaysHits

--- a/src/test/scala/vexriscv/experimental/GenMicro.scala
+++ b/src/test/scala/vexriscv/experimental/GenMicro.scala
@@ -34,14 +34,14 @@ object GenMicro extends App{
             cmdForkOnSecondStage = false,
             cmdForkPersistence = false,
             prediction = NONE,
-            catchAccessFault = false,
+            catchInstructionAccess = false,
             compressedGen = false,
             injectorStage = !removeOneFetchStage,
             rspHoldValue = rspHoldValue
           ),
           new DBusSimplePlugin(
             catchAddressMisaligned = withCompliantCsr,
-            catchAccessFault = false,
+            catchInstructionAccess = false,
             earlyInjection = writeBackOpt,
             onlyLoadWords = onlyLoadWords
           ),
@@ -80,7 +80,7 @@ object GenMicro extends App{
         ) ++ (if(noShifter) Nil else List(new LightShifterPlugin))
          ++ (if(!withCompliantCsr) Nil else List(new CsrPlugin(
           config = if(withCompliantCsrPlusEmulation)CsrPluginConfig(
-            catchIllegalAccess = true,
+            catchInstructionPage = true,
             mvendorid      = null,
             marchid        = null,
             mimpid         = null,
@@ -102,7 +102,7 @@ object GenMicro extends App{
             ucycleAccess   = CsrAccess.NONE,
             noCsrAlu       = true
           ) else CsrPluginConfig(
-            catchIllegalAccess = false,
+            catchInstructionPage = false,
             mvendorid      = null,
             marchid        = null,
             mimpid         = null,


### PR DESCRIPTION
The PMP plugin currently emits instruction, load and store **page** faults (12, 13, 15) but it should emit **access** faults (1, 5, 7). After digging into the code, I realized all of the existing memory translator bus references assume an MMU, not PMP, so I renamed a lot of variables to be more general. All of this is a prerequisite for a combined MMU + PMP plugin, which I may get around to later.

I also renamed the the instruction "catch" variables so they match their meaning in the RISC-V specification. This should make future changes a bit easier to understand:
- `catchIllegalAccess` is now `catchInstructionPage` (12)
- `catchAccessFault` is now `catchInstructionAccess` (1)
- `catchAccessError` is now `catchLoadStoreAccess` (5, 7)
- `catchIllegal` is now `catchLoadStorePage` (13, 15)
- `catchUnaligned` is now `catchLoadStoreMisaligned` (4, 6)