### PR TITLE
Distinguish between page faults from MMU and access faults from PMP

### DIFF
--- a/src/main/scala/vexriscv/Services.scala
+++ b/src/main/scala/vexriscv/Services.scala
@@ -71,6 +71,7 @@ case class MemoryTranslatorCmd() extends Bundle{
 case class MemoryTranslatorRsp() extends Bundle{
   val physicalAddress = UInt(32 bits)
   val isIoAccess = Bool
+  val isPaging = Bool
   val allowRead, allowWrite, allowExecute = Bool
   val exception = Bool
   val refilling = Bool

--- a/src/main/scala/vexriscv/ip/InstructionCache.scala
+++ b/src/main/scala/vexriscv/ip/InstructionCache.scala
@@ -438,9 +438,9 @@ class InstructionCache(p : InstructionCacheConfig) extends Component{
       val mmuRsp = io.cpu.fetch.mmuBus.rsp
 
       io.cpu.fetch.cacheMiss := !hit.valid
-      io.cpu.fetch.error := hit.error
+      io.cpu.fetch.error := hit.error || (!mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute))
       io.cpu.fetch.mmuRefilling := mmuRsp.refilling
-      io.cpu.fetch.mmuException := !mmuRsp.refilling && (mmuRsp.exception || !mmuRsp.allowExecute)
+      io.cpu.fetch.mmuException := !mmuRsp.refilling && mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute)
     })
   }
 
@@ -468,9 +468,9 @@ class InstructionCache(p : InstructionCacheConfig) extends Component{
     }
 
     io.cpu.decode.cacheMiss := !hit.valid
-    io.cpu.decode.error := hit.error
+    io.cpu.decode.error := hit.error || (!mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute))
     io.cpu.decode.mmuRefilling := mmuRsp.refilling
-    io.cpu.decode.mmuException := !mmuRsp.refilling && (mmuRsp.exception || !mmuRsp.allowExecute)
+    io.cpu.decode.mmuException := !mmuRsp.refilling && mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute)
     io.cpu.decode.physicalAddress := mmuRsp.physicalAddress
   })
 }

--- a/src/main/scala/vexriscv/plugin/DBusCachedPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusCachedPlugin.scala
@@ -273,14 +273,13 @@ class DBusCachedPlugin(val config : DataCacheConfig,
           exceptionBus.valid := True
           exceptionBus.code := (input(MEMORY_WR) ? U(7) | U(5)).resized
         }
-
-        if (catchUnaligned) when(cache.io.cpu.writeBack.unalignedAccess) {
-          exceptionBus.valid := True
-          exceptionBus.code := (input(MEMORY_WR) ? U(6) | U(4)).resized
-        }
         if(catchIllegal) when (cache.io.cpu.writeBack.mmuException) {
           exceptionBus.valid := True
           exceptionBus.code := (input(MEMORY_WR) ? U(15) | U(13)).resized
+        }
+        if (catchUnaligned) when(cache.io.cpu.writeBack.unalignedAccess) {
+          exceptionBus.valid := True
+          exceptionBus.code := (input(MEMORY_WR) ? U(6) | U(4)).resized
         }
 
         when(cache.io.cpu.redo) {

--- a/src/main/scala/vexriscv/plugin/MmuPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/MmuPlugin.scala
@@ -127,6 +127,7 @@ class MmuPlugin(ioRange : UInt => Bool,
           port.bus.rsp.allowExecute := cacheLine.allowExecute
           port.bus.rsp.exception := cacheHit && (cacheLine.exception || cacheLine.allowUser && privilegeService.isSupervisor() && !csr.status.sum || !cacheLine.allowUser && privilegeService.isUser())
           port.bus.rsp.refilling := !cacheHit
+          port.bus.rsp.isPaging := True
         } otherwise {
           port.bus.rsp.physicalAddress := port.bus.cmd.virtualAddress
           port.bus.rsp.allowRead := True
@@ -134,6 +135,7 @@ class MmuPlugin(ioRange : UInt => Bool,
           port.bus.rsp.allowExecute := True
           port.bus.rsp.exception := False
           port.bus.rsp.refilling := False
+          port.bus.rsp.isPaging := False
         }
         port.bus.rsp.isIoAccess := ioRange(port.bus.rsp.physicalAddress)
 

--- a/src/main/scala/vexriscv/plugin/PmpPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/PmpPlugin.scala
@@ -205,6 +205,7 @@ class PmpPlugin(regions : Int, ioRange : UInt => Bool) extends Plugin[VexRiscv] 
         }
 
         port.bus.rsp.isIoAccess := ioRange(port.bus.rsp.physicalAddress)
+        port.bus.rsp.isPaging := False
         port.bus.rsp.exception := False
         port.bus.rsp.refilling := False
         port.bus.busy := False

--- a/src/main/scala/vexriscv/plugin/StaticMemoryTranslatorPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/StaticMemoryTranslatorPlugin.scala
@@ -32,6 +32,7 @@ class StaticMemoryTranslatorPlugin(ioRange : UInt => Bool) extends Plugin[VexRis
         port.bus.rsp.allowWrite := True
         port.bus.rsp.allowExecute := True
         port.bus.rsp.isIoAccess := ioRange(port.bus.rsp.physicalAddress)
+        port.bus.rsp.isPaging := False
         port.bus.rsp.exception := False
         port.bus.rsp.refilling := False
         port.bus.busy := False


### PR DESCRIPTION
VexRiscv was originally implemented before the introduction of PMP, so the `MemoryTranslatorRsp` class has no way of differentiating between faults resulting from the MMU and faults resulting from PMP. This PR adds a new flag called `isPaging` to indicate whether the `allowRead`, `allowWrite` and `allowExecute` flags refer to MMU or PMP permissions. This flag is handled by the data and instruction bus plugins to determine whether to throw access faults or page faults.

This fixes a bug where the PMP plugin throws page faults (12, 13, 15) instead of access faults (1, 5, 7) as the specification expects.