### PR TITLE
CFU spec -- update immed data sent in place of RS2.

### DIFF
--- a/src/main/scala/vexriscv/Riscv.scala
+++ b/src/main/scala/vexriscv/Riscv.scala
@@ -16,6 +16,7 @@ object Riscv{
   case class IMM(instruction  : Bits) extends Area{
     // immediates
     def i = instruction(31 downto 20)
+    def h = instruction(31 downto 24)
     def s = instruction(31 downto 25) ## instruction(11 downto 7)
     def b = instruction(31) ## instruction(7) ## instruction(30 downto 25) ## instruction(11 downto 8)
     def u = instruction(31 downto 12) ## U"x000"
@@ -24,6 +25,7 @@ object Riscv{
 
     // sign-extend immediates
     def i_sext = B((19 downto 0) -> i(11)) ## i
+    def h_sext = B((23 downto 0) -> h(7))  ## h
     def s_sext = B((19 downto 0) -> s(11)) ## s
     def b_sext = B((18 downto 0) -> b(11)) ## b ## False
     def j_sext = B((10 downto 0) -> j(19)) ## j ## False

--- a/src/main/scala/vexriscv/plugin/CfuPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CfuPlugin.scala
@@ -187,7 +187,7 @@ class CfuPlugin(val stageCount : Int,
       if(p.CFU_INPUTS >= 1) bus.cmd.inputs(0) := input(RS1)
       if(p.CFU_INPUTS >= 2)  bus.cmd.inputs(1) := input(CFU_INPUT_2_KIND).mux(
         CfuPlugin.Input2Kind.RS -> input(RS2),
-        CfuPlugin.Input2Kind.IMM_I -> IMM(input(INSTRUCTION)).i_sext
+        CfuPlugin.Input2Kind.IMM_I -> IMM(input(INSTRUCTION)).h_sext
       )
     }
 

--- a/src/main/scala/vexriscv/plugin/CfuPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CfuPlugin.scala
@@ -114,7 +114,7 @@ class CfuPlugin(val stageCount : Int,
   val CFU_ENABLE = new Stageable(Bool()).setCompositeName(this, "CFU_ENABLE")
   val CFU_IN_FLIGHT = new Stageable(Bool()).setCompositeName(this, "CFU_IN_FLIGHT")
   val CFU_ENCODING = new Stageable(UInt(log2Up(encodings.size) bits)).setCompositeName(this, "CFU_ENCODING")
-  val CFU_INPUT_2_KIND = new Stageable(CfuPlugin.Input2Kind()).setCompositeName(this, "CFU_ENCODING")
+  val CFU_INPUT_2_KIND = new Stageable(CfuPlugin.Input2Kind()).setCompositeName(this, "CFU_INPUT_2_KIND")
 
   override def setup(pipeline: VexRiscv): Unit = {
     import pipeline._


### PR DESCRIPTION
Define "h" [31:24] and "h_sext" (sign extended "h"), and use it as the IMMED field in the CFU plugin.

Also cherry-pick a fix from dev branch regarding variable names.

