### PR TITLE
PMP Plugin: Fix PMP region size & priority

### DIFF
--- a/src/main/scala/vexriscv/plugin/PmpPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/PmpPlugin.scala
@@ -259,7 +259,7 @@ class PmpPlugin(regions : Int, granularity : Int, ioRange : UInt => Bool) extend
       }
 
       def getPermission(hits : IndexedSeq[Bool], bit : Int) = {
-        (hits zip state.pmpcfg).map({ case (i, cfg) => i & cfg(bit) }).orR
+        MuxOH(OHMasking.first(hits), state.pmpcfg.map(_(bit)))
       }
 
       val dGuard = new Area {


### PR DESCRIPTION
# PMP Region Size

## Existing issue
Currently, the PMP registers will fail to protect the correct memory size. See #202.

## Cause
PMP plugin uses the `getHits()` function to determine if such memory is within the protected region. Since #174, this method applies a mask onto the memory address in question, and compare it with the base address. Both base address (`base`) and mask (`mask`) are generated according to the corresponding PMP address register (`pmpaddrx`).

### Overview of a PMP address register (`pmpaddrx`)
A typlical PMP register in RV32 looks like this. (Credit to @lindemer, this is from the comments in `PmpPlugin.scala`)
```
    3                   2                   1
  1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        address[33:2]                          | pmpaddr#
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```
PMP register is configured using a base address and a mask, separated by a `0` bit in NAPOT mode (Only NAPOT is supported since #174). With the assumption that address width is 32, a NAPOT region may look like this.
```
    3                   2                   1
  1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |0|0|         base_address[31:]         |0|1|1|1|1|1|1|1|1|1|1|1| pmpaddr#
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

### Base Address
Without considering the granularity, `base` can be acquired by setting the trailing ones to zeros, and it was performed correctly.

### Mask
Mask determines the size of the memory chunk that `getHits()` consider a hit.
There are 11 trailing ones, which should correspond to a memory region with 2^(11+3) = 16384 = 0x4000 in size. To match the position of `base` (where it is shifted to the right by 2 bits), the adjusted number should be 0x4000 >> 2 = 0x1000. Therefore, the mask should be ~(0xFFF) (logical NOT) such that all memory within the region would be considered a hit. (Note: Granularity is not considered)

The current implementation with generate `mask` ~(0x3FF). Example where the region size is **exactly** the granularity is explored in #202.

## Solution
**_Conveniently_**, that `~mask` is simply the the trailing ones shifted left and padded with a `1` bit (Trailing ones: 0x7FF, required `~mask`: 0xFFF). Therefore, the patch simply takes the original `ones` and throw away the `xlen-3` bit, and concatenate it with a `1` bit.

## Post-patch
Closes #202

# PMP Region Priority
This is how RISC-V described priority on the privileged manual.
![image](https://user-images.githubusercontent.com/54844539/137845026-11619624-14e7-4e0f-be79-20346f513a22.png)

While on `PmpPlugin.scala`, the order of the registers seems to **not** matter with the use of `orR`.
```
      def getPermission(hits : IndexedSeq[Bool], bit : Int) = {
        (hits zip pmpcfg).map({ case (i, cfg) => i & cfg(bit) }).orR
      }
```
61f68f0 changes the permission checking logic from using a `MuxOH` (@lindemer Is there a particular reason for this?).

This patch reverts the logic back to using `MuxOH` as pre- 61f68f0.