### PR TITLE
plugin: CsrPlugin: Init cycle and instret registers

### DIFF
--- a/src/main/scala/vexriscv/plugin/CsrPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CsrPlugin.scala
@@ -689,8 +689,8 @@ class CsrPlugin(val config: CsrPluginConfig) extends Plugin[VexRiscv] with Excep
         val exceptionCode = Reg(UInt(trapCodeWidth bits))
       }
       val mtval = Reg(UInt(xlen bits))
-      val mcycle   = Reg(UInt(64 bits)) randBoot()
-      val minstret = Reg(UInt(64 bits)) randBoot()
+      val mcycle   = Reg(UInt(64 bits)) init(0)
+      val minstret = Reg(UInt(64 bits)) init(0)
 
 
       val medeleg = supervisorGen generate new Area {


### PR DESCRIPTION
Both counters are initialized with "randBoot()". This is fine for FPGA
designs because the registers can be loaded with default values but
ASIC designs require to load the value during a reset.

Since both counters require to start at 0 (read-only CSR registers),
change both registers from "randBoot()" to "init(0)".

Error:

    reg        [63:0]   CsrPlugin_mcycle = 64'b0000000...00000000000;

           |
  Warning : Ignoring unsynthesizable construct. [VLOGPT-37]

Signed-off-by: Daniel Schultz <d.schultz@phytec.de>