### PR TITLE
plugin: DBusSimplePlugin: Remove assert

### DIFF
--- a/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
@@ -518,9 +518,6 @@ class DBusSimplePlugin(catchAddressMisaligned : Boolean = false,
         }
 
       }
-
-
-      if(rspStage != execute) assert(!(dBus.rsp.ready && input(MEMORY_ENABLE) && arbitration.isValid && arbitration.isStuck),"DBusSimplePlugin doesn't allow memory stage stall when read happend")
     }
 
     //Reformat read responses, REGFILE_WRITE_DATA overriding


### PR DESCRIPTION
This assert triggered sometimes at the beginning of a simulation.
Since it's not really needed anymore, we can remove it.

Signed-off-by: Daniel Schultz <daniel.schultz@aesc-silicon.de>