### PR TITLE
Fix gen simd add resetvector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val spinalVersion = "1.6.3"
+val spinalVersion = "1.6.5"
 
 lazy val root = (project in file(".")).
   settings(

--- a/src/main/scala/vexriscv/Services.scala
+++ b/src/main/scala/vexriscv/Services.scala
@@ -24,6 +24,7 @@ trait DecoderService{
   def add(key : MaskedLiteral,values : Seq[(Stageable[_ <: BaseType],Any)])
   def add(encoding :Seq[(MaskedLiteral,Seq[(Stageable[_ <: BaseType],Any)])])
   def addDefault(key : Stageable[_ <: BaseType], value : Any)
+  def forceIllegal() : Unit
 }
 
 case class ExceptionCause(codeWidth : Int) extends Bundle{

--- a/src/main/scala/vexriscv/VexRiscv.scala
+++ b/src/main/scala/vexriscv/VexRiscv.scala
@@ -136,10 +136,10 @@ class VexRiscv(val config : VexRiscvConfig) extends Component with Pipeline{
   plugins ++= config.plugins
 
   //regression usage
-  val lastStageInstruction = CombInit(stages.last.input(config.INSTRUCTION)).keep().addAttribute (Verilator.public)
-  val lastStagePc = CombInit(stages.last.input(config.PC)).keep().addAttribute(Verilator.public)
-  val lastStageIsValid = CombInit(stages.last.arbitration.isValid).keep().addAttribute(Verilator.public)
-  val lastStageIsFiring = CombInit(stages.last.arbitration.isFiring).keep().addAttribute(Verilator.public)
+  val lastStageInstruction = CombInit(stages.last.input(config.INSTRUCTION)).dontSimplifyIt().addAttribute (Verilator.public)
+  val lastStagePc = CombInit(stages.last.input(config.PC)).dontSimplifyIt().addAttribute(Verilator.public)
+  val lastStageIsValid = CombInit(stages.last.arbitration.isValid).dontSimplifyIt().addAttribute(Verilator.public)
+  val lastStageIsFiring = CombInit(stages.last.arbitration.isFiring).dontSimplifyIt().addAttribute(Verilator.public)
 
   //Verilator perf
   decode.arbitration.removeIt.noBackendCombMerge

--- a/src/main/scala/vexriscv/demo/GenCustomSimdAdd.scala
+++ b/src/main/scala/vexriscv/demo/GenCustomSimdAdd.scala
@@ -13,7 +13,7 @@ object GenCustomSimdAdd extends App{
       plugins = List(
         new SimdAddPlugin,
         new IBusSimplePlugin(
-          resetVector = 0x00000000l,
+          resetVector = 0x80000000l,
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,

--- a/src/main/scala/vexriscv/demo/GenSmallAndProductiveCfu.scala
+++ b/src/main/scala/vexriscv/demo/GenSmallAndProductiveCfu.scala
@@ -70,9 +70,12 @@ object GenSmallAndProductiveCfu extends App{
             CFU_INPUT_DATA_W = 32,
             CFU_OUTPUTS = 1,
             CFU_OUTPUT_DATA_W = 32,
-            CFU_STATE_INDEX_NUM = 5,
             CFU_FLOW_REQ_READY_ALWAYS = false,
-            CFU_FLOW_RESP_READY_ALWAYS = false
+            CFU_FLOW_RESP_READY_ALWAYS = false,
+            CFU_WITH_STATUS = true,
+            CFU_RAW_INSN_W = 32,
+            CFU_CFU_ID_W = 4,
+            CFU_STATE_INDEX_NUM = 5
           )
         ),
         new YamlPlugin("cpu0.yaml")

--- a/src/main/scala/vexriscv/demo/GenSmallAndProductiveCfu.scala
+++ b/src/main/scala/vexriscv/demo/GenSmallAndProductiveCfu.scala
@@ -53,7 +53,6 @@ object GenSmallAndProductiveCfu extends App{
         new CfuPlugin(
           stageCount = 1,
           allowZeroLatency = true,
-          cfuIndexWidth = 4,
           encodings = List(
             CfuPluginEncoding (
               instruction = M"-------------------------0001011",
@@ -64,7 +63,7 @@ object GenSmallAndProductiveCfu extends App{
           busParameter = CfuBusParameter(
             CFU_VERSION = 0,
             CFU_INTERFACE_ID_W = 0,
-            CFU_FUNCTION_ID_W = 7,
+            CFU_FUNCTION_ID_W = 3,
             CFU_REORDER_ID_W = 0,
             CFU_REQ_RESP_ID_W = 0,
             CFU_INPUTS = 2,

--- a/src/main/scala/vexriscv/demo/Murax.scala
+++ b/src/main/scala/vexriscv/demo/Murax.scala
@@ -335,6 +335,54 @@ object Murax{
   }
 }
 
+object MuraxCfu{
+  def main(args: Array[String]) {
+    SpinalVerilog{
+      val config = MuraxConfig.default
+      config.cpuPlugins += new CfuPlugin(
+        stageCount = 1,
+        allowZeroLatency = true,
+        encodings = List(
+          CfuPluginEncoding (
+            instruction = M"-------------------------0001011",
+            functionId = List(14 downto 12),
+            input2Kind = CfuPlugin.Input2Kind.RS
+          )
+        ),
+        busParameter = CfuBusParameter(
+          CFU_VERSION = 0,
+          CFU_INTERFACE_ID_W = 0,
+          CFU_FUNCTION_ID_W = 3,
+          CFU_REORDER_ID_W = 0,
+          CFU_REQ_RESP_ID_W = 0,
+          CFU_INPUTS = 2,
+          CFU_INPUT_DATA_W = 32,
+          CFU_OUTPUTS = 1,
+          CFU_OUTPUT_DATA_W = 32,
+          CFU_FLOW_REQ_READY_ALWAYS = false,
+          CFU_FLOW_RESP_READY_ALWAYS = false,
+          CFU_WITH_STATUS = true,
+          CFU_RAW_INSN_W = 32,
+          CFU_CFU_ID_W = 4,
+          CFU_STATE_INDEX_NUM = 5
+        )
+      )
+
+      val toplevel = Murax(config)
+
+      toplevel.rework {
+        for (plugin <- toplevel.system.cpu.plugins) plugin match {
+          case plugin: CfuPlugin => plugin.bus.toIo().setName("miaou")
+          case _ =>
+        }
+      }
+
+      toplevel
+    }
+  }
+}
+
+
 object Murax_iCE40_hx8k_breakout_board_xip{
 
   case class SB_GB() extends BlackBox{

--- a/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
+++ b/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
@@ -206,7 +206,7 @@ object VexRiscvSmpClusterGen {
         mvendorid      = null,
         marchid        = null,
         mimpid         = null,
-        mhartid        = 0,
+        mhartid        = hartId,
         misaExtensionsInit = 0,
         misaAccess     = CsrAccess.NONE,
         mtvecAccess    = CsrAccess.READ_WRITE,

--- a/src/main/scala/vexriscv/plugin/DecoderSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DecoderSimplePlugin.scala
@@ -71,6 +71,8 @@ class DecoderSimplePlugin(catchIllegalInstruction : Boolean = false,
     }
   }
 
+  def forceIllegal() : Unit = if(catchIllegalInstruction) pipeline.decode.input(pipeline.config.LEGAL_INSTRUCTION) := False
+
   val defaults = mutable.LinkedHashMap[Stageable[_ <: BaseType], BaseType]()
   val encodings = mutable.LinkedHashMap[MaskedLiteral,ArrayBuffer[(Stageable[_ <: BaseType], BaseType)]]()
   var decodeExceptionPort : Flow[ExceptionCause] = null

--- a/src/test/cpp/briey/main.cpp
+++ b/src/test/cpp/briey/main.cpp
@@ -382,6 +382,8 @@ public:
 		timeProcesses.push_back(asyncReset);
 		timeProcesses.push_back(jtag);
 		timeProcesses.push_back(uartRx);
+        top->io_uart_rxd = 1;
+
 
 		SdramConfig *sdramConfig = new SdramConfig(
 			2,  //byteCount


### PR DESCRIPTION
When following the instructions in the README I got ~88 failures with the SimdAdd example (when running the regression).
Comparing to e.g. `GenSmallest` it seemed that the reset vector is off.