### PR TITLE
Fix reset vector of GenCustomSimdAdd

### DIFF
--- a/src/main/scala/vexriscv/demo/GenCustomSimdAdd.scala
+++ b/src/main/scala/vexriscv/demo/GenCustomSimdAdd.scala
@@ -13,7 +13,7 @@ object GenCustomSimdAdd extends App{
       plugins = List(
         new SimdAddPlugin,
         new IBusSimplePlugin(
-          resetVector = 0x00000000l,
+          resetVector = 0x80000000l,
           cmdForkOnSecondStage = false,
           cmdForkPersistence = false,
           prediction = NONE,

--- a/src/test/cpp/custom/simd_add/src/ld
+++ b/src/test/cpp/custom/simd_add/src/ld
@@ -1,13 +1,11 @@
 OUTPUT_ARCH( "riscv" )
 
 MEMORY {
-  onChipRam (W!RX)/*(RX)*/ : ORIGIN = 0x00000000, LENGTH = 8K
+  onChipRam (W!RX)/*(RX)*/ : ORIGIN = 0x80000000, LENGTH = 8K
 }
 
 SECTIONS
 {
-   . = 0x000;
-
    .crt_section :
    {
     . = ALIGN(4);


### PR DESCRIPTION
With the old reset vector half of the tests fail since
they expect the CPU to start at 0x80000000.