### PR TITLE
plugin: caches: Fix "Can't resolve the literal value of"

### DIFF
--- a/src/main/scala/vexriscv/plugin/DBusCachedPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusCachedPlugin.scala
@@ -295,7 +295,7 @@ class DBusCachedPlugin(val config : DataCacheConfig,
 
     pipeline plug new Area{
       //Memory bandwidth counter
-      val rspCounter = RegInit(UInt(32 bits)) init(0)
+      val rspCounter = Reg(UInt(32 bits)) init(0)
       when(dBus.rsp.valid){
         rspCounter := rspCounter + 1
       }

--- a/src/main/scala/vexriscv/plugin/IBusCachedPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusCachedPlugin.scala
@@ -141,7 +141,7 @@ class IBusCachedPlugin(resetVector : BigInt = 0x80000000l,
       iBus.cmd.address.allowOverride := cache.io.mem.cmd.address
 
       //Memory bandwidth counter
-      val rspCounter = RegInit(UInt(32 bits)) init(0)
+      val rspCounter = Reg(UInt(32 bits)) init(0)
       when(iBus.rsp.valid){
         rspCounter := rspCounter + 1
       }


### PR DESCRIPTION
Both registers were initialized with unsigned integers without a value.
This triggered:

[error] Exception in thread "main" spinal.core.SpinalExit:
[error]  Can't resolve the literal value of (..._rspCounter :  UInt[32 bits])

Signed-off-by: Daniel Schultz <dnltz@aesc-silicon.de>