### PR TITLE
Expose satp

### DIFF
--- a/src/main/scala/vexriscv/plugin/CsrPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CsrPlugin.scala
@@ -82,6 +82,7 @@ case class CsrPluginConfig(
                             deterministicInteruptionEntry : Boolean = false, //Only used for simulatation purposes
                             wfiOutput           : Boolean = false,
                             withPrivilegedDebug : Boolean = false, //For the official RISC-V debug spec implementation
+                            exportPrivilege     : Boolean = false,
                             var debugTriggers       : Int     = 2
                           ){
   assert(!ucycleAccess.canWrite)
@@ -612,6 +613,9 @@ class CsrPlugin(val config: CsrPluginConfig) extends Plugin[VexRiscv] with Excep
     contextSwitching = Bool().setName("contextSwitching")
 
     privilege = UInt(2 bits).setName("CsrPlugin_privilege")
+    if (exportPrivilege) {
+      val export_priv = out(privilege)
+    }
     forceMachineWire = False
 
     if(catchIllegalAccess || ecallGen || withEbreak)

--- a/src/main/scala/vexriscv/plugin/CsrPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CsrPlugin.scala
@@ -613,9 +613,7 @@ class CsrPlugin(val config: CsrPluginConfig) extends Plugin[VexRiscv] with Excep
     contextSwitching = Bool().setName("contextSwitching")
 
     privilege = UInt(2 bits).setName("CsrPlugin_privilege")
-    if (exportPrivilege) {
-      val export_priv = out(privilege)
-    }
+    if (exportPrivilege) out(privilege)
     forceMachineWire = False
 
     if(catchIllegalAccess || ecallGen || withEbreak)

--- a/src/main/scala/vexriscv/plugin/MmuPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/MmuPlugin.scala
@@ -93,18 +93,12 @@ class MmuPlugin(ioRange : UInt => Bool,
         val sum, mxr, mprv = RegInit(False)
         mprv clearWhen(csrService.xretAwayFromMachine)
       }
-      val satp = if(exportSatp) {
-        new Area {
-          val mode = out(RegInit(False))
-          val asid = out(Reg(Bits(9 bits)))
-          // Bottom 20 bits are used in implementation, but top 2 bits are still stored for OS use.
-          val ppn = out(Reg(UInt(22 bits)))
-        }
-      } else {
-        new Area {
-          val mode = RegInit(False)
-          val asid = Reg(Bits(9 bits))
-          val ppn = Reg(UInt(22 bits))
+      val satp = new Area {
+        val mode = RegInit(False)
+        val asid = Reg(Bits(9 bits))
+        val ppn = Reg(UInt(22 bits)) // Bottom 20 bits are used in implementation, but top 2 bits are still stored for OS use.
+        if(exportSatp) {
+          out(mode, asid, ppn)
         }
       }
 


### PR DESCRIPTION
This PR adds a flag that allows the configuration to expose the SATP value for external inspection.

The primary motivation for this is to allow hardware to determine, when a system is running in virtual memory mode, if a given process is allowed to access sensitive data. The operative theory is that the SATP is intimately linked to the virtual process that is running, and by exposing this data outside the core we can make decisions about the state of the machine easily.

Hopefully the flag is coded in a way that users which do not care about this feature are not impacted by it. Let me know if you would prefer it coded in a different way for minimal impact on most users who do not share such security concerns.
