### PR TITLE
CsrPlugin: insert FORMAL_HALT := False

### DIFF
--- a/src/main/scala/vexriscv/plugin/CsrPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CsrPlugin.scala
@@ -670,6 +670,10 @@ class CsrPlugin(val config: CsrPluginConfig) extends Plugin[VexRiscv] with Excep
       }
     }
 
+    // The CSR plugin will invoke a trap handler on exception, which does not
+    // count as halt-state by the RVFI spec, and neither do other instructions
+    // such as `wfi`, etc. Hence statically drive the output:
+    pipeline.stages.head.insert(FORMAL_HALT) := False
 
     case class Xtvec() extends Bundle {
       val mode = Bits(2 bits)


### PR DESCRIPTION
The `FormalPlugin` requires a `FORMAL_HALT` insert to indicate whether the CPU will halt after retiring the current instruction. As this insert is provided only by the `HaltOnExceptionPlugin`, and the `CsrPlugin` also provides a conflicting `ExceptionService`, currently the `FormalPlugin` can't be used with the `CsrPlugin`. As there is no way to halt the CPU with the `CsrPlugin`, simply deassert `FORMAL_HALT`.