### PR TITLE
{I,D}BusSimplePlugin: don't rely on `memoryTranslatorPortConfig != null`

### DIFF
--- a/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
@@ -455,7 +455,7 @@ class DBusSimplePlugin(catchAddressMisaligned : Boolean = false,
 
         //do not emit memory request if MMU refilling
         insert(MMU_FAULT) := input(MMU_RSP).exception || (!input(MMU_RSP).allowWrite && input(MEMORY_STORE)) || (!input(MMU_RSP).allowRead && !input(MEMORY_STORE))
-        skipCmd.setWhen(input(MMU_FAULT) || input(MMU_RSP).refilling)
+        skipCmd.setWhen(input(MMU_RSP).refilling)
 
         insert(MMU_RSP) := mmuBus.rsp
       }

--- a/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
@@ -255,7 +255,10 @@ class IBusSimplePlugin(    resetVector : BigInt,
 
   var iBus : IBusSimpleBus = null
   var decodeExceptionPort : Flow[ExceptionCause] = null
-  val catchSomething = memoryTranslatorPortConfig != null || catchAccessFault
+  // Whether the IBus plugin should catch faults. Automatically determined
+  // in setup based on whether catchAccessFault is set or the pipeline has a
+  // MemoryTranslator plugin.
+  var catchSomething = false;
   var mmuBus : MemoryTranslatorBus = null
 
 //  if(rspHoldValue) assert(busLatencyMin <= 1)
@@ -266,6 +269,8 @@ class IBusSimplePlugin(    resetVector : BigInt,
     super.setup(pipeline)
     iBus = master(IBusSimpleBus(this)).setName("iBus")
 
+    catchSomething = pipeline.serviceExist(classOf[MemoryTranslator]) || catchAccessFault
+
     val decoderService = pipeline.service(classOf[DecoderService])
     decoderService.add(FENCE_I, Nil)
 
@@ -273,7 +278,7 @@ class IBusSimplePlugin(    resetVector : BigInt,
       decodeExceptionPort = pipeline.service(classOf[ExceptionService]).newExceptionPort(pipeline.decode,1)
     }
 
-    if(memoryTranslatorPortConfig != null) {
+    if(pipeline.serviceExist(classOf[MemoryTranslator])) {
       mmuBus = pipeline.service(classOf[MemoryTranslator]).newTranslationPort(MemoryTranslatorPort.PRIORITY_INSTRUCTION, memoryTranslatorPortConfig)
     }
   }
@@ -403,7 +408,7 @@ class IBusSimplePlugin(    resetVector : BigInt,
             decodeExceptionPort.code  := 1
             exceptionDetected := True
           }
-          if(memoryTranslatorPortConfig != null) {
+          if(mmuBus != null) {
             val privilegeService = pipeline.serviceElse(classOf[PrivilegeService], PrivilegeServiceDefault())
             when(stages.last.input.valid && !mmu.joinCtx.refilling && (mmu.joinCtx.exception || !mmu.joinCtx.allowExecute)){
               decodeExceptionPort.code  := 12


### PR DESCRIPTION
`null` can be a valid `MemoryTranslator` configuration parameter, for example in the case of the `PmpPlugin`. Furthermore, the `IBusCachedPlugin` and `DBusCachedPlugin` do not generally rely on its `memoryTranslatorPortConfig` to be non-null to instantiate its translator port, but instead checks whether a `MemoryTranslator` service exists in the pipeline. Thus it seems best to change `IBusSimplePlugin` and `DBusSimplePlugin` to behave identically to the their respective cached versions.  This also prevents accidental CPU misconfigurations where an MMU or PMP plugin is instantiated and generally usable, but does not actually take effect in the memory buses.

As an unintended side-effect, when pairing this change with use of the `PmpPlugin` or `PmpPluginOld`, this will now result in a combinational loop over the `skipCmd`, `arbitration.isValid`, and `MMU_FAULT` signals. For now, I have simply avoided this by not setting `skipCmd` when there is an `MMU_FAULT`, given that this fault should still be caught despite a load being performed. While this seems to work for my initial tests,

- it needs more extensive testing, and
- I'm not sure whether there might be a better solution here.

Hence this is a draft PR and I am looking for feedback on how to resolve the combinational loop issues.