### PR TITLE
Remove sbt-assembly dependency

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
The plugin is not used in the VexRiscV build and causes issues for users since repo.scala-sbt.org seems to be down/sunset/?.

See also https://github.com/sbt/sbt/issues/7202

Updating the dependency would also have been an option, but since it's not used removal is easier.