### PR TITLE
Add cmd halfPipe function to DBusSimpleBus

### DIFF
--- a/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
@@ -103,6 +103,13 @@ case class DBusSimpleBus(bigEndian : Boolean = false) extends Bundle with IMaste
     s
   }
 
+  def cmdHalfPipe() : DBusSimpleBus = {
+    val s = DBusSimpleBus(bigEndian)
+    s.cmd << this.cmd.halfPipe()
+    s.rsp <> this.rsp
+    s
+  }
+
   def genMask(cmd : DBusSimpleCmd) = {
     if(bigEndian)
       cmd.size.mux(
@@ -245,7 +252,7 @@ case class DBusSimpleBus(bigEndian : Boolean = false) extends Bundle with IMaste
     }
     bus
   }
-  
+
   def toBmb() : Bmb = {
     val pipelinedMemoryBusConfig = DBusSimpleBus.getBmbParameter()
     val bus = Bmb(pipelinedMemoryBusConfig)

--- a/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
@@ -106,7 +106,7 @@ case class DBusSimpleBus(bigEndian : Boolean = false) extends Bundle with IMaste
   def cmdHalfPipe() : DBusSimpleBus = {
     val s = DBusSimpleBus(bigEndian)
     s.cmd << this.cmd.halfPipe()
-    s.rsp <> this.rsp
+    s.rsp >> this.rsp
     s
   }
 


### PR DESCRIPTION
Motivated by https://github.com/SpinalHDL/VexRiscv/issues/347#issuecomment-1587520015.

Adds a function called `cmdHalfPipe` to `DBusSimpleBus` which allows for a simple `halfPipe()` insertion on the `cmd` Stream in order to break combinatorial loops(when necessary).

Tested manually on board with Briey that used AhbLite3 interconnect(which forces the use of DBusSimplePlugin since Cached plugin does not have the `toAhbLite3Master()` function)