### PR TITLE
Fix ambiguous function call to bind()

### DIFF
--- a/src/test/cpp/common/jtag.h
+++ b/src/test/cpp/common/jtag.h
@@ -82,7 +82,7 @@ public:
 		memset(serverAddr.sin_zero, '\0', sizeof serverAddr.sin_zero);
 
 		//---- Bind the address struct to the socket ----//
-		bind(serverSocket, (struct sockaddr *) &serverAddr, sizeof(serverAddr));
+		::bind(serverSocket, (struct sockaddr *) &serverAddr, sizeof(serverAddr));
 
 		//---- Listen on the socket, with 5 max connection requests queued ----//
 		listen(serverSocket,1);


### PR DESCRIPTION
The call to `bind()` can actually resolve to `std::bind()` instead of libc's `bind()`.
This fix ensures that we're definitely always calling the correct `bind()`.

Took me way too long to hunt this one down...

This happened with `clang++ 16.0.6`.