### PR TITLE
Fix SMP compile-time error when disabling supervisor option

### DIFF
--- a/src/main/scala/vexriscv/VexRiscv.scala
+++ b/src/main/scala/vexriscv/VexRiscv.scala
@@ -53,6 +53,11 @@ case class VexRiscvConfig(){
     case None => false
   }
 
+  def withSupervisor = find(classOf[CsrPlugin]) match {
+    case Some(x) => x.config.supervisorGen
+    case None => false
+  }
+
   def FLEN = if(withRvd) 64 else if(withRvf) 32 else 0
 
   //Default Stageables

--- a/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
+++ b/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
@@ -206,7 +206,9 @@ class VexRiscvSmpClusterWithPeripherals(p : VexRiscvSmpClusterParameter) extends
     plic.priorityWidth.load(2)
     plic.mapping.load(PlicMapping.sifive)
     plic.addTarget(core.cpu.externalInterrupt)
-    plic.addTarget(core.cpu.externalSupervisorInterrupt)
+    if(core.cpu.config.withSupervisor) {
+      plic.addTarget(core.cpu.externalSupervisorInterrupt)
+    }
     List(clint.logic, core.cpu.logic).produce {
       for (plugin <- core.cpu.config.plugins) plugin match {
         case plugin: CsrPlugin if plugin.utime != null => plugin.utime := clint.logic.io.time


### PR DESCRIPTION
When generating SMP configuration with supervisor disable, the compiler stucks at waiting for the signal from
`externalSupervisorInterrupt`, which is generated conditionally based on `withSupervisor` in CsrPlugin.