### PR TITLE
Handle `ERR` in `toWishbone`

### DIFF
--- a/src/main/scala/vexriscv/ip/DataCache.scala
+++ b/src/main/scala/vexriscv/ip/DataCache.scala
@@ -368,13 +368,13 @@ case class DataCacheMemBus(p : DataCacheConfig) extends Bundle with IMasterSlave
     bus.WE  := cmdBridge.wr
     bus.DAT_MOSI := cmdBridge.data
 
-    cmdBridge.ready := cmdBridge.valid && bus.ACK
+    cmdBridge.ready := cmdBridge.valid && (bus.ACK || bus.ERR)
     bus.CYC := cmdBridge.valid
     bus.STB := cmdBridge.valid
 
-    rsp.valid := RegNext(cmdBridge.valid && !bus.WE && bus.ACK) init(False)
+    rsp.valid := RegNext(cmdBridge.valid && !bus.WE && (bus.ACK || bus.ERR)) init(False)
     rsp.data  := RegNext(bus.DAT_MISO)
-    rsp.error := False //TODO
+    rsp.error := RegNext(bus.ERR)
     bus
   }
 

--- a/src/main/scala/vexriscv/ip/InstructionCache.scala
+++ b/src/main/scala/vexriscv/ip/InstructionCache.scala
@@ -239,15 +239,15 @@ case class InstructionCacheMemBus(p : InstructionCacheConfig) extends Bundle wit
     when(cmd.valid || pending){
       bus.CYC := True
       bus.STB := True
-      when(bus.ACK){
+      when(bus.ACK || bus.ERR){
         counter := counter + 1
       }
     }
 
-    cmd.ready := cmd.valid && bus.ACK
-    rsp.valid := RegNext(bus.CYC && bus.ACK) init(False)
+    cmd.ready := cmd.valid && (bus.ACK || bus.ERR)
+    rsp.valid := RegNext(bus.CYC && (bus.ACK || bus.ERR)) init(False)
     rsp.data := RegNext(bus.DAT_MISO)
-    rsp.error := False //TODO
+    rsp.error := RegNext(bus.ERR)
     bus
   }
 

--- a/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/DBusSimplePlugin.scala
@@ -199,13 +199,13 @@ case class DBusSimpleBus(bigEndian : Boolean = false) extends Bundle with IMaste
     bus.WE  := cmdStage.wr
     bus.DAT_MOSI := cmdStage.data
 
-    cmdStage.ready := cmdStage.valid && bus.ACK
+    cmdStage.ready := cmdStage.valid && (bus.ACK || bus.ERR)
     bus.CYC := cmdStage.valid
     bus.STB := cmdStage.valid
 
-    rsp.ready := cmdStage.valid && !bus.WE && bus.ACK
+    rsp.ready := cmdStage.valid && !bus.WE && (bus.ACK || bus.ERR)
     rsp.data  := bus.DAT_MISO
-    rsp.error := False //TODO
+    rsp.error := bus.ERR
     bus
   }
 

--- a/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
@@ -156,10 +156,10 @@ case class IBusSimpleBus(plugin: IBusSimplePlugin) extends Bundle with IMasterSl
     bus.STB := cmdPipe.valid
 
 
-    cmdPipe.ready := cmdPipe.valid && bus.ACK
-    rsp.valid := bus.CYC && bus.ACK
+    cmdPipe.ready := cmdPipe.valid && (bus.ACK || bus.ERR)
+    rsp.valid := bus.CYC && (bus.ACK || bus.ERR)
     rsp.inst := bus.DAT_MISO
-    rsp.error := False //TODO
+    rsp.error := bus.ERR
     bus
   }
 


### PR DESCRIPTION
This PR implements handling `ERR` in `toWishbone`. 

Note that the following may look strange:

```scala
  cmdBridge.ready := cmdBridge.valid && (bus.ACK || bus.ERR)
```

But this is imposed by the Wishbone spec:

> *Rule 3.45*
> If a SLAVE supports the `[ERR_O]` or `[RTY_O]` signals, then the SLAVE MUST NOT assert more than one of the following signals at any time: `[ACK_O]`, `[ERR_O]` or `[RTY_O]`.

----------

Questions for reviewers:

 * Is there an example regression test for, say, AXI error handling I could use as a base for a Wishbone test?
 * Where can I add a changelog entry (if applicable)?