### PR TITLE
Fix undriven signal

### DIFF
--- a/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
+++ b/src/main/scala/vexriscv/plugin/IBusSimplePlugin.scala
@@ -371,6 +371,7 @@ class IBusSimplePlugin(    resetVector : BigInt,
         }
 
         val fetchRsp = FetchRsp()
+        fetchRsp.isRvc := False
         fetchRsp.pc := stages.last.output.payload
         fetchRsp.rsp := rspBuffer.output.payload
         fetchRsp.rsp.error.clearWhen(!rspBuffer.output.valid) //Avoid interference with instruction injection from the debug plugin


### PR DESCRIPTION
So I am using https://github.com/efabless/openlane2/ to synthesize VexRiscv for SKY130, and I am facing synthesis issues due to an undriven pin:
Verilator Linting:
```
%Warning-UNDRIVEN: VexRiscv.v:780:23: Signal is not driven: 'IBusSimplePlugin_rspJoin_fetchRsp_isRvc'
                                                                               : ... note: In instance 'top.VexRiscv_inst'
  780 |   wire                IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Resulting error: `ABC: Error: The network is combinational.`

Thanks to verilator's linting, I was able to pin down the signal that is missing an assignment.
However, since I am not familiar with code base, my proposed "fix" might not be semantically correct, but at least fixes the synthesis issues.

For the sake of completeness, this is the openlane config.json that I am using:
```
{
"DESIGN_NAME": "VexRiscv",
"VERILOG_FILES": "dir::src/*",
"CLOCK_PORT": "clk",
"CLOCK_NET": "clk",
"DESIGN_IS_CORE": false,
"RUN_KLAYOUT_XOR": 0,
"RUN_KLAYOUT_DRC": 0,
"CLOCK_PERIOD": 50,
"FP_CORE_UTIL": 20
}
```