### PR TITLE
Make TDATA2 RW. Openocd requires this for hw breakpoints

### DIFF
--- a/src/main/scala/vexriscv/plugin/CsrPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CsrPlugin.scala
@@ -942,12 +942,12 @@ class CsrPlugin(val config: CsrPluginConfig) extends Plugin[VexRiscv] with Excep
           }
 
           val tdata2 = new Area{
-            val value = Reg(PC)
-            csrw(CSR.TDATA2, 0 -> value)
+            val value = Reg(Bits(32 bits))
+            csrrw(CSR.TDATA2, value, 0 -> value)
 
             val execute = new Area{
               val enabled = !debugMode && tdata1.action === 1 && tdata1.execute && tdata1.privilegeHit
-              val hit =  enabled && value === decode.input(PC)
+              val hit =  enabled && value.asUInt === decode.input(PC)
               decodeBreak.enabled.setWhen(hit)
             }
           }


### PR DESCRIPTION
https://riscv.org/wp-content/uploads/2024/12/riscv-debug-release.pdf

> Most trigger functionality is optional. All tdata registers follow write-any-read-legal semantics. If a
debugger writes an unsupported configuration, the register will read back a value that is supported
(which may simply be a disabled trigger). This means that a debugger must always read back
values it writes to tdata registers, unless it already knows already what is supported. Writes to
one tdata register may not modify the contents of other tdata registers, nor the configuration of
any trigger besides the one that is currently selected.

OpenOCD in particular reads back this value and if it doesn't match; won't use the breakpoint
