### PR TITLE
Bump to Spinal version 1.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val spinalVersion = "1.10.2a"
+val spinalVersion = "1.12.0"
 
 lazy val root = (project in file(".")).
   settings(

--- a/build.sc
+++ b/build.sc
@@ -1,6 +1,6 @@
 import mill._, scalalib._
 
-val spinalVersion = "1.10.1"
+val spinalVersion = "1.12.0"
 
 object ivys {
   val sv = "2.11.12"


### PR DESCRIPTION
Codebase requires int support in isPow2, the latest version of spinal has this support.