### PR TITLE
EmbeddedRiscvJtag support for system bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1465,6 +1465,41 @@ init
 halt
 ```
 
+##### System Bus
+The EmbeddedRiscvJtag plugin can also be configured to support system bus accesses per the RISC-V Debug Specification v1.0. This allows memory access without impacting CPU execution and can be handy when a debug host is regularly polling (e.g. RTT logging).
+
+```scala
+new EmbeddedRiscvJtag(
+  p = DebugTransportModuleParameter(
+    addressWidth = 7,
+    version      = 1,
+    idle         = 7
+  ),
+  withTunneling = false,
+  withTap = true,
+  withSysBus = true
+)
+```
+
+Then connect `sysBus` to your logic just like a data bus (`sysBus` is a `DBusSimpleBus`).
+
+```scala
+var debugSysBus: Axi4Shared = null
+
+...
+
+for (plugin <- cpuConfig.plugins) plugin match {
+  case plugin: EmbeddedRiscvJtag => {
+    debugSysBus = plugin.sysBus.toAxi4Shared()
+  }
+  case _ =>
+}
+
+...
+
+// Connect debugSysBus to a crossbar, etc.
+```
+
 #### YamlPlugin
 
 This plugin offers a service to other plugins to generate a useful Yaml file describing the CPU configuration. It contains, for instance, the sequence of instructions required

--- a/src/main/scala/vexriscv/plugin/EmbeddedRiscvJtag.scala
+++ b/src/main/scala/vexriscv/plugin/EmbeddedRiscvJtag.scala
@@ -50,9 +50,9 @@ class EmbeddedRiscvJtag(var p : DebugTransportModuleParameter,
           xlen = XLEN,
           flen = pipeline.config.FLEN,
           withFpuRegAccess = pipeline.config.FLEN == 64
-        ))
+        )),
+        withSysBus = withSysBus
       ),
-      withSysBus = withSysBus
     )
     if (withSysBus) {
       sysBus = master(DBusSimpleBus())

--- a/src/main/scala/vexriscv/plugin/EmbeddedRiscvJtag.scala
+++ b/src/main/scala/vexriscv/plugin/EmbeddedRiscvJtag.scala
@@ -16,7 +16,8 @@ class EmbeddedRiscvJtag(var p : DebugTransportModuleParameter,
                         var debugCd : ClockDomain = null,
                         var jtagCd : ClockDomain = null,
                         var withTap : Boolean = true,
-                        var withTunneling : Boolean = false
+                        var withTunneling : Boolean = false,
+                        var withSysBus : Boolean = false
                         ) extends Plugin[VexRiscv] with VexRiscvRegressionArg{
 
 
@@ -25,6 +26,7 @@ class EmbeddedRiscvJtag(var p : DebugTransportModuleParameter,
   var jtag : Jtag = null
   var jtagInstruction : JtagTapInstructionCtrl = null
   var ndmreset : Bool = null
+  var sysBus : DBusSimpleBus = null
 
 
   def setDebugCd(cd : ClockDomain) : this.type = {debugCd = cd; this}
@@ -49,8 +51,23 @@ class EmbeddedRiscvJtag(var p : DebugTransportModuleParameter,
           flen = pipeline.config.FLEN,
           withFpuRegAccess = pipeline.config.FLEN == 64
         ))
-      )
+      ),
+      withSysBus = withSysBus
     )
+    if (withSysBus) {
+      sysBus = master(DBusSimpleBus())
+
+      sysBus.cmd.valid := dm.io.sysBus.cmd.valid
+      dm.io.sysBus.cmd.ready := sysBus.cmd.ready
+      sysBus.cmd.payload.wr := dm.io.sysBus.cmd.wr
+      sysBus.cmd.payload.address := dm.io.sysBus.cmd.address
+      sysBus.cmd.payload.data := dm.io.sysBus.cmd.data
+      sysBus.cmd.payload.size := dm.io.sysBus.cmd.size
+
+      dm.io.sysBus.rsp.ready := sysBus.rsp.ready
+      dm.io.sysBus.rsp.error := sysBus.rsp.error
+      dm.io.sysBus.rsp.data := sysBus.rsp.data
+    }
 
     ndmreset := dm.io.ndmreset
 


### PR DESCRIPTION
# Description
This change adds an optional system bus sysBus to the EmbeddedRiscvJtag plugin to support 32-bit read+write accesses per RISC-V Debug Specification v1.0.

When enabled using `withSysBus = true`, the plugin exposes a `DBusSimpleBus` connected to the DebugModule's system bus. Only 32-bit addresses and accesses are supported for now, but this change could be extended for 128, 64, 16, or 8 bit accesses (see referenced SpinalHDL PR)

**Depends on this SpinalHDL PR**
https://github.com/SpinalHDL/SpinalHDL/pull/1768
(DebugModule system bus support)

# Motivation and Context
Without system bus support, debug memory accesses must go through the CPU. I noticed this when building Rust firmware for a VexRiscV based system with RTT logging. When running the firmware with probe-rs, the host continuously looks for new logs in a ring buffer in memory. Without system bus support, this causes delays in the firmware's execution during those memory polls--not helpful when you're working on something with real-time requirements!