### PR TITLE
Pass `jtagId` in `EmbeddedRiscvJtag`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1385,7 +1385,8 @@ new EmbeddedRiscvJtag(
     idle         = 7
   ),
   withTunneling = false,
-  withTap = true
+  withTap = true,
+  jtagId = 0x10002FFF
 )
 ```
 

--- a/src/main/scala/vexriscv/plugin/EmbeddedRiscvJtag.scala
+++ b/src/main/scala/vexriscv/plugin/EmbeddedRiscvJtag.scala
@@ -16,7 +16,8 @@ class EmbeddedRiscvJtag(var p : DebugTransportModuleParameter,
                         var debugCd : ClockDomain = null,
                         var jtagCd : ClockDomain = null,
                         var withTap : Boolean = true,
-                        var withTunneling : Boolean = false
+                        var withTunneling : Boolean = false,
+                        var jtagId : Int = 0x10002FFF
                         ) extends Plugin[VexRiscv] with VexRiscvRegressionArg{
 
 
@@ -57,7 +58,8 @@ class EmbeddedRiscvJtag(var p : DebugTransportModuleParameter,
     val dmiDirect = if(withTap && !withTunneling) new Area {
       val logic = DebugTransportModuleJtagTap(
         p.copy(addressWidth = 7),
-        debugCd = ClockDomain.current
+        debugCd = ClockDomain.current,
+        jtagId = jtagId
       )
       dm.io.ctrl <> logic.io.bus
       logic.io.jtag <> jtag


### PR DESCRIPTION
I know main development is now at `VexiiRiscv`, but I hope this patch is small/uncontroversial enough to make it through. Thanks a lot.