### PR TITLE
Tweaks to allow Compilation on both Scala 2.13 and 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ lazy val root = (project in file(".")).
     inThisBuild(List(
       organization       := "com.github.spinalhdl",
       crossScalaVersions := Seq("2.13.18", "2.12.18"),
+      scalaVersion       := "2.13.18",
       version            := "2.1.0"
     )),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file(".")).
     inThisBuild(List(
       organization       := "com.github.spinalhdl",
       crossScalaVersions := Seq("2.13.18", "2.12.18"),
-      scalaVersion       := "2.13.18",
+      scalaVersion       := "2.12.18",
       version            := "2.1.0"
     )),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization       := "com.github.spinalhdl",
-      crossScalaVersions := Seq("2.13.18", "2.12.18"),
+      crossScalaVersions := Seq("2.12.18", "2.13.18"),
       scalaVersion       := "2.12.18",
       version            := "2.1.0"
     )),

--- a/build.sbt
+++ b/build.sbt
@@ -3,15 +3,15 @@ val spinalVersion = "1.13.0"
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
-      organization := "com.github.spinalhdl",
-      scalaVersion := "2.12.18",
-      version      := "2.0.0"
+      organization       := "com.github.spinalhdl",
+      crossScalaVersions := Seq("2.13.18", "2.12.18"),
+      version            := "2.1.0"
     )),
     libraryDependencies ++= Seq(
       "com.github.spinalhdl" %% "spinalhdl-core" % spinalVersion,
       "com.github.spinalhdl" %% "spinalhdl-lib" % spinalVersion,
       compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % spinalVersion),
-      "org.scalatest" %% "scalatest" % "3.2.17",
+      "org.scalatest" %% "scalatest" % "3.2.17" % Test,
       "org.yaml" % "snakeyaml" % "1.8"
     ),
     name := "VexRiscv"

--- a/src/main/scala/vexriscv/demo/VexRiscvAxi4LinuxPlicClint.scala
+++ b/src/main/scala/vexriscv/demo/VexRiscvAxi4LinuxPlicClint.scala
@@ -148,11 +148,11 @@ object VexRiscvAxi4LinuxPlicClint{
               .parent = null //Avoid the io bundle to be interpreted as a QSys conduit
           }
           case plugin: CsrPlugin => {
-            plugin.timerInterrupt     setAsDirectionLess() := cpu.clintCtrl.io.timerInterrupt(0)
-            plugin.softwareInterrupt  setAsDirectionLess() := cpu.clintCtrl.io.softwareInterrupt(0)
-            plugin.externalInterrupt  setAsDirectionLess() := cpu.plicCtrl.io.targets(0)
-            plugin.externalInterruptS setAsDirectionLess() := cpu.plicCtrl.io.targets(1)
-            plugin.utime              setAsDirectionLess() := cpu.clintCtrl.io.time
+            plugin.timerInterrupt     .setAsDirectionLess() := cpu.clintCtrl.io.timerInterrupt(0)
+            plugin.softwareInterrupt  .setAsDirectionLess() := cpu.clintCtrl.io.softwareInterrupt(0)
+            plugin.externalInterrupt  .setAsDirectionLess() := cpu.plicCtrl.io.targets(0)
+            plugin.externalInterruptS .setAsDirectionLess() := cpu.plicCtrl.io.targets(1)
+            plugin.utime              .setAsDirectionLess() := cpu.clintCtrl.io.time
           }
           case _ =>
         }

--- a/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
+++ b/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
@@ -53,7 +53,7 @@ class VexRiscvSmpClusterBase(p : VexRiscvSmpClusterParameter) extends Area with 
     this
   }
 
-  implicit val interconnect = BmbInterconnectGenerator()
+  implicit val interconnect: BmbInterconnectGenerator = BmbInterconnectGenerator()
 
   val customDebug = !p.privilegedDebug generate new Area {
     val debugBridge = debugCd.outputClockDomain on JtagInstructionDebuggerGenerator(p.jtagHeaderIgnoreWidth)

--- a/src/main/scala/vexriscv/demo/smp/VexRiscvSmpLitexCluster.scala
+++ b/src/main/scala/vexriscv/demo/smp/VexRiscvSmpLitexCluster.scala
@@ -154,7 +154,7 @@ object VexRiscvLitexSmpClusterCmdGen extends App {
     opt[String]("itlb-size") action { (v, c) => iTlbSize = v.toInt }
     opt[String]("dtlb-size") action { (v, c) => dTlbSize = v.toInt }
     opt[String]("expose-time") action { (v, c) => exposeTime = v.toBoolean }
-  }.parse(args, Unit).nonEmpty)
+  }.parse(args, ()).nonEmpty)
 
   val coherency = coherentDma || cpuCount > 1
   def parameter = VexRiscvLitexSmpClusterParameter(

--- a/src/main/scala/vexriscv/demo/smp/VexRiscvSmpLitexMpCluster.scala
+++ b/src/main/scala/vexriscv/demo/smp/VexRiscvSmpLitexMpCluster.scala
@@ -7,6 +7,8 @@ import spinal.lib.bus.wishbone.{WishboneConfig, WishboneToBmbGenerator}
 import spinal.lib.sim.SparseMemory
 import vexriscv.demo.smp.VexRiscvSmpClusterGen.vexRiscvConfig
 
+case class __Unused_Because_EmptyCompilationUnitsCauseScala213IncrementalCompilationIssues();
+
 //case class VexRiscvLitexSmpMpClusterParameter( cluster : VexRiscvSmpClusterParameter,
 //                                             liteDram : LiteDramNativeParameter,
 //                                             liteDramMapping : AddressMapping)

--- a/src/main/scala/vexriscv/ip/DataCache.scala
+++ b/src/main/scala/vexriscv/ip/DataCache.scala
@@ -114,7 +114,7 @@ case class DataCacheConfig(cacheSize : Int,
 }
 
 object DataCacheCpuExecute{
-  implicit def implArgs(that : DataCacheCpuExecute) = that.args
+  implicit def implArgs(that : DataCacheCpuExecute): DataCacheCpuExecuteArgs = that.args
 }
 
 case class DataCacheCpuExecute(p : DataCacheConfig) extends Bundle with IMasterSlave{

--- a/src/main/scala/vexriscv/plugin/CsrPlugin.scala
+++ b/src/main/scala/vexriscv/plugin/CsrPlugin.scala
@@ -841,7 +841,7 @@ class CsrPlugin(val config: CsrPluginConfig) extends Plugin[VexRiscv] with Excep
               goto(IDLE)
             }
           }
-          build()
+          this.build()
         }
 
 


### PR DESCRIPTION
Hello,

I needed support for Scala 2.13 so I forked VexRiscV and added it as a cross target.  My fork certainly works for my use-case and I thought I'd contribute back as it may be of use to yourselves and others that wish to integrate.

Basically, in the absence of packages, it allows me to build via SBT as a sub-module like this:

```scala
ThisBuild / scalaVersion := "2.13.18"

// ...

val spinalVersion = "1.13.0"

lazy val root = (project in file("."))
	.settings(
		// ...
		libraryDependencies ++= Seq(
			"org.scalatest" %% "scalatest" % "3.2.17" % Test,
			"com.github.spinalhdl" %% "spinalhdl-core" % spinalVersion,
			"com.github.spinalhdl" %% "spinalhdl-lib" % spinalVersion,
			compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % spinalVersion)))

	.dependsOn(vexriscv)

lazy val vexriscv = RootProject(uri("https://github.com/pete-restall/fork-VexRiscv.git#3261ef67efd64f9d2c21ed9b55f0ea3a1bb62d58"))
```

I'm happy to tweak it if you need me to.

Cheers.