### PR TITLE
Add IHP SG13G2 L1 Caches

### DIFF
--- a/src/main/scala/vexriscv/ihp/sg13g2/Memory.scala
+++ b/src/main/scala/vexriscv/ihp/sg13g2/Memory.scala
@@ -1,0 +1,112 @@
+package vexriscv.ihp.sg13g2
+
+import spinal.core._
+
+object Memory {
+  def apply(width: Int, size: Int): IHPSG13Memory = (width, size) match {
+    case (32, 1024) => RM_IHPSG13_2P_256x32_c2_bm_bist()
+    case (22, 1024) => RM_IHPSG13_2P_64x22_c2()
+    case _ => throw new IllegalArgumentException(s"Unsupported width and size: $width x $size")
+  }
+
+  abstract class IHPSG13Memory(val addrWidth: Int, val dataWidth: Int) extends BlackBox {
+    val A_CLK = in(Bool())
+    val A_MEN = in(Bool())
+    val A_WEN = in(Bool())
+    val A_REN = in(Bool())
+    val A_ADDR = in(Bits(addrWidth bits))
+    val A_DIN = in(Bits(dataWidth bits))
+    val A_DLY = in(Bool())
+    val A_DOUT = out(Bits(dataWidth bits))
+
+    val B_CLK = in(Bool())
+    val B_MEN = in(Bool())
+    val B_WEN = in(Bool())
+    val B_REN = in(Bool())
+    val B_ADDR = in(Bits(addrWidth bits))
+    val B_DIN = in(Bits(dataWidth bits))
+    val B_DLY = in(Bool())
+    val B_DOUT = out(Bits(dataWidth bits))
+
+    def connectDefaults() {
+      this.A_DLY := True
+      this.B_DLY := True
+    }
+
+
+    mapCurrentClockDomain(A_CLK)
+    mapCurrentClockDomain(B_CLK)
+  }
+
+  case class RM_IHPSG13_2P_256x32_c2_bm_bist()
+      extends IHPSG13Memory(addrWidth = 8, dataWidth = 32) {
+
+    val A_BM = in(Bits(dataWidth bits))
+    val B_BM = in(Bits(dataWidth bits))
+
+    val A_BIST_CLK = in(Bool())
+    val A_BIST_EN = in(Bool())
+    val A_BIST_MEN = in(Bool())
+    val A_BIST_WEN = in(Bool())
+    val A_BIST_REN = in(Bool())
+    val A_BIST_ADDR = in(Bits(addrWidth bits))
+    val A_BIST_DIN = in(Bits(dataWidth bits))
+    val A_BIST_BM = in(Bits(dataWidth bits))
+
+    val B_BIST_CLK = in(Bool())
+    val B_BIST_EN = in(Bool())
+    val B_BIST_MEN = in(Bool())
+    val B_BIST_WEN = in(Bool())
+    val B_BIST_REN = in(Bool())
+    val B_BIST_ADDR = in(Bits(addrWidth bits))
+    val B_BIST_DIN = in(Bits(dataWidth bits))
+    val B_BIST_BM = in(Bits(dataWidth bits))
+
+    override def connectDefaults() {
+      this.A_DLY := True
+      this.B_DLY := True
+
+      this.A_BM := B(dataWidth bits, default -> True)
+      this.B_BM := B(dataWidth bits, default -> True)
+
+      this.A_BIST_CLK := False
+      this.A_BIST_EN := False
+      this.A_BIST_MEN := False
+      this.A_BIST_WEN := False
+      this.A_BIST_REN := False
+      this.A_BIST_ADDR := 0
+      this.A_BIST_DIN := 0
+      this.A_BIST_BM := 0
+
+      this.B_BIST_CLK := False
+      this.B_BIST_EN := False
+      this.B_BIST_MEN := False
+      this.B_BIST_WEN := False
+      this.B_BIST_REN := False
+      this.B_BIST_ADDR := 0
+      this.B_BIST_DIN := 0
+      this.B_BIST_BM := 0
+    }
+
+    addRTLPath(
+      System.getenv("VEXRISCV_ROOT") +
+      "src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_core_behavioral_ideal.v"
+    )
+    addRTLPath(
+      System.getenv("VEXRISCV_ROOT") +
+      "src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_256x32_c2_bm_bist.v"
+    )
+  }
+
+  case class RM_IHPSG13_2P_64x22_c2()
+      extends IHPSG13Memory(addrWidth = 6, dataWidth = 22) {
+    addRTLPath(
+      System.getenv("VEXRISCV_ROOT") +
+      "src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_core_behavioral_bm_bist_ideal.v"
+    )
+    addRTLPath(
+      System.getenv("VEXRISCV_ROOT") +
+      "src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_64x22_c2.v"
+    )
+  }
+}

--- a/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_256x32_c2_bm_bist.v
+++ b/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_256x32_c2_bm_bist.v
@@ -1,0 +1,293 @@
+// ------------------------------------------------------
+//
+//		Copyright 2025 IHP PDK Authors
+//
+//		Licensed under the Apache License, Version 2.0 (the "License");
+//		you may not use this file except in compliance with the License.
+//		You may obtain a copy of the License at
+//
+//		   https://www.apache.org/licenses/LICENSE-2.0
+//
+//		Unless required by applicable law or agreed to in writing, software
+//		distributed under the License is distributed on an "AS IS" BASIS,
+//		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//		See the License for the specific language governing permissions and
+//		limitations under the License.
+//
+//		Generated on Wed Aug 27 13:14:43 2025
+//
+// ------------------------------------------------------
+`celldefine
+module RM_IHPSG13_2P_256x32_c2_bm_bist (
+    A_CLK,
+    A_MEN,
+    A_WEN,
+    A_REN,
+    A_ADDR,
+    A_DIN,
+    A_DLY,
+    A_DOUT,
+    A_BM,
+    A_BIST_CLK,
+    A_BIST_EN,
+    A_BIST_MEN,
+    A_BIST_WEN,
+    A_BIST_REN,
+    A_BIST_ADDR,
+    A_BIST_DIN,
+    A_BIST_BM,
+    B_CLK,
+    B_MEN,
+    B_WEN,
+    B_REN,
+    B_ADDR,
+    B_DIN,
+    B_DLY,
+    B_DOUT,
+    B_BM,
+    B_BIST_CLK,
+    B_BIST_EN,
+    B_BIST_MEN,
+    B_BIST_WEN,
+    B_BIST_REN,
+    B_BIST_ADDR,
+    B_BIST_DIN,
+    B_BIST_BM
+);
+
+    input A_CLK;
+    input A_MEN;
+    input A_WEN;
+    input A_REN;
+    input [7:0] A_ADDR;
+    input [31:0] A_DIN;
+    input A_DLY;
+    output [31:0] A_DOUT;
+    input [31:0] A_BM;
+    input A_BIST_CLK;
+    input A_BIST_EN;
+    input A_BIST_MEN;
+    input A_BIST_WEN;
+    input A_BIST_REN;
+    input [7:0] A_BIST_ADDR;
+    input [31:0] A_BIST_DIN;
+    input [31:0] A_BIST_BM;
+    input B_CLK;
+    input B_MEN;
+    input B_WEN;
+    input B_REN;
+    input [7:0] B_ADDR;
+    input [31:0] B_DIN;
+    input B_DLY;
+    output [31:0] B_DOUT;
+    input [31:0] B_BM;
+    input B_BIST_CLK;
+    input B_BIST_EN;
+    input B_BIST_MEN;
+    input B_BIST_WEN;
+    input B_BIST_REN;
+    input [7:0] B_BIST_ADDR;
+    input [31:0] B_BIST_DIN;
+    input [31:0] B_BIST_BM;
+
+`define SYNTHESIS
+`define FUNCTIONAL
+
+`ifdef FUNCTIONAL  //  functional //
+
+
+    SRAM_2P_behavioral_bm_bist #(
+	.P_DATA_WIDTH(32),
+	.P_ADDR_WIDTH(8)
+	) i_SRAM_2P_behavioral_bm_bist (
+                    .A_CLK(A_CLK),
+                    .A_MEN(A_MEN),
+                    .A_WEN(A_WEN),
+                    .A_REN(A_REN),
+                    .A_ADDR(A_ADDR),
+                    .A_DLY(A_DLY),
+                    .A_DIN(A_DIN),
+                    .A_DOUT(A_DOUT),
+                    .A_BM(A_BM),
+                    .A_BIST_CLK(A_BIST_CLK),
+                    .A_BIST_EN(A_BIST_EN),
+                    .A_BIST_MEN(A_BIST_MEN),
+                    .A_BIST_WEN(A_BIST_WEN),
+                    .A_BIST_REN(A_BIST_REN),
+                    .A_BIST_ADDR(A_BIST_ADDR),
+                    .A_BIST_DIN(A_BIST_DIN),
+                    .A_BIST_BM(A_BIST_BM),
+                    .B_CLK(B_CLK),
+                    .B_MEN(B_MEN),
+                    .B_WEN(B_WEN),
+                    .B_REN(B_REN),
+                    .B_ADDR(B_ADDR),
+                    .B_DLY(B_DLY),
+                    .B_DIN(B_DIN),
+                    .B_DOUT(B_DOUT),
+                    .B_BM(B_BM),
+                    .B_BIST_CLK(B_BIST_CLK),
+                    .B_BIST_EN(B_BIST_EN),
+                    .B_BIST_MEN(B_BIST_MEN),
+                    .B_BIST_WEN(B_BIST_WEN),
+                    .B_BIST_REN(B_BIST_REN),
+                    .B_BIST_ADDR(B_BIST_ADDR),
+                    .B_BIST_DIN(B_BIST_DIN),
+                    .B_BIST_BM(B_BIST_BM)
+		);
+
+`else
+
+    wire A_CLK_DELAY;
+    wire A_MEN_DELAY;
+    wire A_WEN_DELAY;
+    wire A_REN_DELAY;
+    wire [7:0] A_ADDR_DELAY;
+    wire [31:0] A_DIN_DELAY;
+    wire [31:0] A_BM_DELAY;
+    wire A_BIST_CLK_DELAY;
+    wire A_BIST_MEN_DELAY;
+    wire A_BIST_WEN_DELAY;
+    wire A_BIST_REN_DELAY;
+    wire [7:0] A_BIST_ADDR_DELAY;
+    wire [31:0] A_BIST_DIN_DELAY;
+    wire [31:0] A_BIST_BM_DELAY;
+    wire B_CLK_DELAY;
+    wire B_MEN_DELAY;
+    wire B_WEN_DELAY;
+    wire B_REN_DELAY;
+    wire [7:0] B_ADDR_DELAY;
+    wire [31:0] B_DIN_DELAY;
+    wire [31:0] B_BM_DELAY;
+    wire B_BIST_CLK_DELAY;
+    wire B_BIST_MEN_DELAY;
+    wire B_BIST_WEN_DELAY;
+    wire B_BIST_REN_DELAY;
+    wire [7:0] B_BIST_ADDR_DELAY;
+    wire [31:0] B_BIST_DIN_DELAY;
+    wire [31:0] B_BIST_BM_DELAY;
+
+    reg notifier;
+
+    wire A_RW_ACCESS = (A_WEN || A_REN) && A_MEN;
+    wire A_W_ACCESS  = A_WEN && A_MEN;
+    wire A_BIST_RW_ACCESS = (A_BIST_WEN || A_BIST_REN) && A_BIST_MEN;
+    wire A_BIST_W_ACCESS  = A_BIST_WEN && A_BIST_MEN;
+
+    wire B_RW_ACCESS = (B_WEN || B_REN) && B_MEN;
+    wire B_W_ACCESS  = B_WEN && B_MEN;
+    wire B_BIST_RW_ACCESS = (B_BIST_WEN || B_BIST_REN) && B_BIST_MEN;
+    wire B_BIST_W_ACCESS  = B_BIST_WEN && B_BIST_MEN;
+
+
+    SRAM_2P_behavioral_bm_bist #(
+	.P_DATA_WIDTH(32),
+	.P_ADDR_WIDTH(8)
+	) i_SRAM_2P_behavioral_bm_bist (
+                    .A_CLK(A_CLK_DELAY),
+                    .A_MEN(A_MEN_DELAY),
+                    .A_WEN(A_WEN_DELAY),
+                    .A_REN(A_REN_DELAY),
+                    .A_ADDR(A_ADDR_DELAY),
+                    .A_DLY(A_DLY),
+                    .A_DIN(A_DIN_DELAY),
+                    .A_DOUT(A_DOUT),
+                    .A_BM(A_BM_DELAY),
+                    .A_BIST_CLK(A_BIST_CLK_DELAY),
+                    .A_BIST_EN(A_BIST_EN),
+                    .A_BIST_MEN(A_BIST_MEN_DELAY),
+                    .A_BIST_WEN(A_BIST_WEN_DELAY),
+                    .A_BIST_REN(A_BIST_REN_DELAY),
+                    .A_BIST_ADDR(A_BIST_ADDR_DELAY),
+                    .A_BIST_DIN(A_BIST_DIN_DELAY),
+                    .A_BIST_BM(A_BIST_BM_DELAY),
+                    .B_CLK(B_CLK_DELAY),
+                    .B_MEN(B_MEN_DELAY),
+                    .B_WEN(B_WEN_DELAY),
+                    .B_REN(B_REN_DELAY),
+                    .B_ADDR(B_ADDR_DELAY),
+                    .B_DLY(B_DLY),
+                    .B_DIN(B_DIN_DELAY),
+                    .B_DOUT(B_DOUT),
+                    .B_BM(B_BM_DELAY),
+                    .B_BIST_CLK(B_BIST_CLK_DELAY),
+                    .B_BIST_EN(B_BIST_EN),
+                    .B_BIST_MEN(B_BIST_MEN_DELAY),
+                    .B_BIST_WEN(B_BIST_WEN_DELAY),
+                    .B_BIST_REN(B_BIST_REN_DELAY),
+                    .B_BIST_ADDR(B_BIST_ADDR_DELAY),
+                    .B_BIST_DIN(B_BIST_DIN_DELAY),
+                    .B_BIST_BM(B_BIST_BM_DELAY)
+		);
+
+
+    specify
+
+      (posedge A_CLK *> (A_DOUT : A_DIN)) = (1.0, 1.0);
+      $width(posedge A_CLK, 1.0,0,notifier);
+      $setuphold(posedge A_CLK &&& A_MEN, posedge A_MEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_MEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, posedge A_REN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_REN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, posedge A_WEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_WEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, negedge A_MEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_MEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, negedge A_REN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_REN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, negedge A_WEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_WEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_RW_ACCESS, posedge A_ADDR, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_ADDR_DELAY);
+      $setuphold(posedge A_CLK &&& A_RW_ACCESS, negedge A_ADDR, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_ADDR_DELAY);
+
+      $setuphold(posedge A_CLK &&& A_W_ACCESS, posedge A_DIN, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_DIN_DELAY);
+      $setuphold(posedge A_CLK &&& A_W_ACCESS, negedge A_DIN, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_DIN_DELAY);
+      $setuphold(posedge A_CLK &&& A_W_ACCESS, posedge A_BM, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_BM_DELAY);
+      $setuphold(posedge A_CLK &&& A_W_ACCESS, negedge A_BM, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_BM_DELAY);
+      (posedge A_BIST_CLK *> (A_DOUT : A_BIST_DIN)) = (1.0, 1.0);
+      $width(posedge A_BIST_CLK, 1.0,0,notifier);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_MEN, posedge A_BIST_MEN, 1.0, 1.0,notifier,,,A_BIST_CLK_DELAY, A_BIST_MEN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_MEN, posedge A_BIST_REN, 1.0, 1.0,notifier,,,A_BIST_CLK_DELAY, A_BIST_REN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_MEN, posedge A_BIST_WEN, 1.0, 1.0,notifier,,,A_BIST_CLK_DELAY, A_BIST_WEN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_MEN, negedge A_BIST_MEN, 1.0, 1.0,notifier,,,A_BIST_CLK_DELAY, A_BIST_MEN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_MEN, negedge A_BIST_REN, 1.0, 1.0,notifier,,,A_BIST_CLK_DELAY, A_BIST_REN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_MEN, negedge A_BIST_WEN, 1.0, 1.0,notifier,,,A_BIST_CLK_DELAY, A_BIST_WEN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_RW_ACCESS, posedge A_BIST_ADDR, 1.0 ,1.0, notifier,,,A_BIST_CLK_DELAY, A_BIST_ADDR_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_RW_ACCESS, negedge A_BIST_ADDR, 1.0 ,1.0, notifier,,,A_BIST_CLK_DELAY, A_BIST_ADDR_DELAY);
+
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_W_ACCESS, posedge A_BIST_DIN, 1.0 ,1.0, notifier,,,A_BIST_CLK_DELAY, A_BIST_DIN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_W_ACCESS, negedge A_BIST_DIN, 1.0 ,1.0, notifier,,,A_BIST_CLK_DELAY, A_BIST_DIN_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_W_ACCESS, posedge A_BIST_BM, 1.0 ,1.0, notifier,,,A_BIST_CLK_DELAY, A_BIST_BM_DELAY);
+      $setuphold(posedge A_BIST_CLK &&& A_BIST_W_ACCESS, negedge A_BIST_BM, 1.0 ,1.0, notifier,,,A_BIST_CLK_DELAY, A_BIST_BM_DELAY);
+
+      (posedge B_CLK *> (B_DOUT : B_DIN)) = (1.0, 1.0);
+      $width(posedge B_CLK, 1.0,0,notifier);
+      $setuphold(posedge B_CLK &&& B_MEN, posedge B_MEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_MEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, posedge B_REN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_REN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, posedge B_WEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_WEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, negedge B_MEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_MEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, negedge B_REN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_REN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, negedge B_WEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_WEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_RW_ACCESS, posedge B_ADDR, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_ADDR_DELAY);
+      $setuphold(posedge B_CLK &&& B_RW_ACCESS, negedge B_ADDR, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_ADDR_DELAY);
+
+      $setuphold(posedge B_CLK &&& B_W_ACCESS, posedge B_DIN, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_DIN_DELAY);
+      $setuphold(posedge B_CLK &&& B_W_ACCESS, negedge B_DIN, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_DIN_DELAY);
+      $setuphold(posedge B_CLK &&& B_W_ACCESS, posedge B_BM, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_BM_DELAY);
+      $setuphold(posedge B_CLK &&& B_W_ACCESS, negedge B_BM, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_BM_DELAY);
+      (posedge B_BIST_CLK *> (B_DOUT : B_BIST_DIN)) = (1.0, 1.0);
+      $width(posedge B_BIST_CLK, 1.0,0,notifier);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_MEN, posedge B_BIST_MEN, 1.0, 1.0,notifier,,,B_BIST_CLK_DELAY, B_BIST_MEN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_MEN, posedge B_BIST_REN, 1.0, 1.0,notifier,,,B_BIST_CLK_DELAY, B_BIST_REN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_MEN, posedge B_BIST_WEN, 1.0, 1.0,notifier,,,B_BIST_CLK_DELAY, B_BIST_WEN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_MEN, negedge B_BIST_MEN, 1.0, 1.0,notifier,,,B_BIST_CLK_DELAY, B_BIST_MEN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_MEN, negedge B_BIST_REN, 1.0, 1.0,notifier,,,B_BIST_CLK_DELAY, B_BIST_REN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_MEN, negedge B_BIST_WEN, 1.0, 1.0,notifier,,,B_BIST_CLK_DELAY, B_BIST_WEN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_RW_ACCESS, posedge B_BIST_ADDR, 1.0 ,1.0, notifier,,,B_BIST_CLK_DELAY, B_BIST_ADDR_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_RW_ACCESS, negedge B_BIST_ADDR, 1.0 ,1.0, notifier,,,B_BIST_CLK_DELAY, B_BIST_ADDR_DELAY);
+
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_W_ACCESS, posedge B_BIST_DIN, 1.0 ,1.0, notifier,,,B_BIST_CLK_DELAY, B_BIST_DIN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_W_ACCESS, negedge B_BIST_DIN, 1.0 ,1.0, notifier,,,B_BIST_CLK_DELAY, B_BIST_DIN_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_W_ACCESS, posedge B_BIST_BM, 1.0 ,1.0, notifier,,,B_BIST_CLK_DELAY, B_BIST_BM_DELAY);
+      $setuphold(posedge B_BIST_CLK &&& B_BIST_W_ACCESS, negedge B_BIST_BM, 1.0 ,1.0, notifier,,,B_BIST_CLK_DELAY, B_BIST_BM_DELAY);
+
+    endspecify
+
+`endif
+
+endmodule
+`endcelldefine

--- a/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_64x22_c2.v
+++ b/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_64x22_c2.v
@@ -1,0 +1,204 @@
+// ------------------------------------------------------
+//
+//		Copyright 2025 IHP PDK Authors
+//
+//		Licensed under the Apache License, Version 2.0 (the "License");
+//		you may not use this file except in compliance with the License.
+//		You may obtain a copy of the License at
+//
+//		   https://www.apache.org/licenses/LICENSE-2.0
+//
+//		Unless required by applicable law or agreed to in writing, software
+//		distributed under the License is distributed on an "AS IS" BASIS,
+//		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//		See the License for the specific language governing permissions and
+//		limitations under the License.
+//
+//		Generated on Mon Jan 19 16:01:28 2026
+//
+// ------------------------------------------------------
+`timescale 1ns/10ps
+`celldefine
+module RM_IHPSG13_2P_64x22_c2 (
+    A_CLK,
+    A_MEN,
+    A_WEN,
+    A_REN,
+    A_ADDR,
+    A_DIN,
+    A_DLY,
+    A_DOUT,
+    B_CLK,
+    B_MEN,
+    B_WEN,
+    B_REN,
+    B_ADDR,
+    B_DIN,
+    B_DLY,
+    B_DOUT
+);
+
+    input A_CLK;
+    input A_MEN;
+    input A_WEN;
+    input A_REN;
+    input [5:0] A_ADDR;
+    input [21:0] A_DIN;
+    input A_DLY;
+    output [21:0] A_DOUT;
+    input B_CLK;
+    input B_MEN;
+    input B_WEN;
+    input B_REN;
+    input [5:0] B_ADDR;
+    input [21:0] B_DIN;
+    input B_DLY;
+    output [21:0] B_DOUT;
+
+`define SYNTHESIS
+`define FUNCTIONAL
+
+// ---- Simulation-only check: A_DLY must be tied high ----------------------
+`ifndef SYNTHESIS
+    initial begin
+      #0; // check at t=0 (after elaboration)
+      if (A_DLY !== 1'b1) begin
+        $display("%m ERROR: A_DLY must be tied to 1'b1 (saw %b) at time %0t.", A_DLY, $time);
+        $stop; // use $finish if you prefer to exit completely
+      end
+    end
+
+    always @(A_DLY) begin
+      if (A_DLY !== 1'b1) begin
+        $display("%m ERROR: A_DLY must remain 1'b1 (observed %b) at time %0t.", A_DLY, $time);
+        $stop;
+      end
+    end
+`endif
+
+// ---- Simulation-only check: B_DLY must be tied high ----------------------
+`ifndef SYNTHESIS
+    initial begin
+      #0; // check at t=0 (after elaboration)
+      if (B_DLY !== 1'b1) begin
+        $display("%m ERROR: B_DLY must be tied to 1'b1 (saw %b) at time %0t.", B_DLY, $time);
+        $stop; // use $finish if you prefer to exit completely
+      end
+    end
+
+    always @(B_DLY) begin
+      if (B_DLY !== 1'b1) begin
+        $display("%m ERROR: B_DLY must remain 1'b1 (observed %b) at time %0t.", B_DLY, $time);
+        $stop;
+      end
+    end
+`endif
+
+`ifdef FUNCTIONAL  //  functional //
+
+
+    SRAM_2P_behavioral #(
+	.P_DATA_WIDTH(22),
+	.P_ADDR_WIDTH(6)
+	) i_SRAM_2P_behavioral (
+                    .A_CLK(A_CLK),
+                    .A_MEN(A_MEN),
+                    .A_WEN(A_WEN),
+                    .A_REN(A_REN),
+                    .A_ADDR(A_ADDR),
+                    .A_DLY(A_DLY),
+                    .A_DIN(A_DIN),
+                    .A_DOUT(A_DOUT),
+                    .B_CLK(B_CLK),
+                    .B_MEN(B_MEN),
+                    .B_WEN(B_WEN),
+                    .B_REN(B_REN),
+                    .B_ADDR(B_ADDR),
+                    .B_DLY(B_DLY),
+                    .B_DIN(B_DIN),
+                    .B_DOUT(B_DOUT)
+		);
+
+`else
+
+    wire A_CLK_DELAY;
+    wire A_MEN_DELAY;
+    wire A_WEN_DELAY;
+    wire A_REN_DELAY;
+    wire [5:0] A_ADDR_DELAY;
+    wire [21:0] A_DIN_DELAY;
+    wire B_CLK_DELAY;
+    wire B_MEN_DELAY;
+    wire B_WEN_DELAY;
+    wire B_REN_DELAY;
+    wire [5:0] B_ADDR_DELAY;
+    wire [21:0] B_DIN_DELAY;
+
+    reg notifier;
+
+    wire A_RW_ACCESS = (A_WEN || A_REN) && A_MEN;
+    wire A_W_ACCESS  = A_WEN && A_MEN;
+
+    wire B_RW_ACCESS = (B_WEN || B_REN) && B_MEN;
+    wire B_W_ACCESS  = B_WEN && B_MEN;
+
+
+    SRAM_2P_behavioral #(
+	.P_DATA_WIDTH(22),
+	.P_ADDR_WIDTH(6)
+	) i_SRAM_2P_behavioral (
+                    .A_CLK(A_CLK_DELAY),
+                    .A_MEN(A_MEN_DELAY),
+                    .A_WEN(A_WEN_DELAY),
+                    .A_REN(A_REN_DELAY),
+                    .A_ADDR(A_ADDR_DELAY),
+                    .A_DLY(A_DLY),
+                    .A_DIN(A_DIN_DELAY),
+                    .A_DOUT(A_DOUT),
+                    .B_CLK(B_CLK_DELAY),
+                    .B_MEN(B_MEN_DELAY),
+                    .B_WEN(B_WEN_DELAY),
+                    .B_REN(B_REN_DELAY),
+                    .B_ADDR(B_ADDR_DELAY),
+                    .B_DLY(B_DLY),
+                    .B_DIN(B_DIN_DELAY),
+                    .B_DOUT(B_DOUT)
+		);
+
+
+    specify
+
+      (posedge A_CLK *> (A_DOUT : A_DIN)) = (1.0, 1.0);
+      $width(posedge A_CLK, 1.0,0,notifier);
+      $setuphold(posedge A_CLK &&& A_MEN, posedge A_MEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_MEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, posedge A_REN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_REN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, posedge A_WEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_WEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, negedge A_MEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_MEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, negedge A_REN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_REN_DELAY);
+      $setuphold(posedge A_CLK &&& A_MEN, negedge A_WEN, 1.0, 1.0,notifier,,,A_CLK_DELAY, A_WEN_DELAY);
+      $setuphold(posedge A_CLK &&& A_RW_ACCESS, posedge A_ADDR, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_ADDR_DELAY);
+      $setuphold(posedge A_CLK &&& A_RW_ACCESS, negedge A_ADDR, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_ADDR_DELAY);
+
+      $setuphold(posedge A_CLK &&& A_W_ACCESS, posedge A_DIN, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_DIN_DELAY);
+      $setuphold(posedge A_CLK &&& A_W_ACCESS, negedge A_DIN, 1.0 ,1.0, notifier,,,A_CLK_DELAY, A_DIN_DELAY);
+
+      (posedge B_CLK *> (B_DOUT : B_DIN)) = (1.0, 1.0);
+      $width(posedge B_CLK, 1.0,0,notifier);
+      $setuphold(posedge B_CLK &&& B_MEN, posedge B_MEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_MEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, posedge B_REN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_REN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, posedge B_WEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_WEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, negedge B_MEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_MEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, negedge B_REN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_REN_DELAY);
+      $setuphold(posedge B_CLK &&& B_MEN, negedge B_WEN, 1.0, 1.0,notifier,,,B_CLK_DELAY, B_WEN_DELAY);
+      $setuphold(posedge B_CLK &&& B_RW_ACCESS, posedge B_ADDR, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_ADDR_DELAY);
+      $setuphold(posedge B_CLK &&& B_RW_ACCESS, negedge B_ADDR, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_ADDR_DELAY);
+
+      $setuphold(posedge B_CLK &&& B_W_ACCESS, posedge B_DIN, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_DIN_DELAY);
+      $setuphold(posedge B_CLK &&& B_W_ACCESS, negedge B_DIN, 1.0 ,1.0, notifier,,,B_CLK_DELAY, B_DIN_DELAY);
+
+    endspecify
+
+`endif
+
+endmodule
+`endcelldefine

--- a/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_core_behavioral_bm_bist_ideal.v
+++ b/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_core_behavioral_bm_bist_ideal.v
@@ -1,0 +1,198 @@
+// ------------------------------------------------------
+//
+//		Copyright 2025 IHP PDK Authors
+//
+//		Licensed under the Apache License, Version 2.0 (the "License");
+//		you may not use this file except in compliance with the License.
+//		You may obtain a copy of the License at
+//
+//		   https://www.apache.org/licenses/LICENSE-2.0
+//
+//		Unless required by applicable law or agreed to in writing, software
+//		distributed under the License is distributed on an "AS IS" BASIS,
+//		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//		See the License for the specific language governing permissions and
+//		limitations under the License.
+//
+//		Generated on Tue Sep  9 10:49:23 2025
+//
+// ------------------------------------------------------
+module SRAM_2P_behavioral_bm_bist(//inputs port
+                          A_CLK,
+                          A_DLY,
+                          A_MEN,
+                          A_ADDR,
+                          A_DIN,
+                          A_BM,
+                          A_WEN,
+                          A_REN,
+
+                          //output port a
+                          A_DOUT,
+
+                          A_BIST_EN,
+                          A_BIST_ADDR,
+                          A_BIST_DIN,
+                          A_BIST_BM,
+                          A_BIST_MEN,
+                          A_BIST_WEN,
+                          A_BIST_REN,
+                          A_BIST_CLK,
+
+
+                          //inputs port b
+                          B_CLK,
+                          B_DLY,
+                          B_MEN,
+                          B_ADDR,
+                          B_DIN,
+                          B_BM,
+                          B_WEN,
+                          B_REN,
+
+                          //output port b
+                          B_DOUT,
+
+                          B_BIST_EN,
+                          B_BIST_ADDR,
+                          B_BIST_DIN,
+                          B_BIST_BM,
+                          B_BIST_MEN,
+                          B_BIST_WEN,
+                          B_BIST_REN,
+                          B_BIST_CLK);
+
+
+
+parameter P_DATA_WIDTH =  20;
+parameter P_ADDR_WIDTH =  9;
+
+parameter P_ADDR_COUNT = 2**P_ADDR_WIDTH; //2^P_ADDR_WIDTH
+
+parameter      P_FORCE_ERROR    = 0;
+parameter [P_ADDR_WIDTH:0]    P_ERROR_ADDR    = 50;
+parameter [P_DATA_WIDTH-1:0]  P_ERROR_PATTERN     = 40'h0000000000;
+
+//inputs port a
+input                    A_CLK;
+input                    A_DLY;
+input                    A_MEN;
+input [P_ADDR_WIDTH-1:0] A_ADDR;
+input [P_DATA_WIDTH-1:0] A_DIN;
+input [P_DATA_WIDTH-1:0] A_BM;
+input                    A_WEN;
+input                    A_REN;
+
+//output port a
+output [P_DATA_WIDTH-1:0] A_DOUT;
+
+input                    A_BIST_EN;
+input [P_ADDR_WIDTH-1:0] A_BIST_ADDR;
+input [P_DATA_WIDTH-1:0] A_BIST_DIN;
+input [P_DATA_WIDTH-1:0] A_BIST_BM;
+input                    A_BIST_MEN;
+input                    A_BIST_WEN;
+input                    A_BIST_REN;
+input                    A_BIST_CLK;
+
+
+//inputs port b
+input                    B_CLK;
+input                    B_DLY;
+input                    B_MEN;
+input [P_ADDR_WIDTH-1:0] B_ADDR;
+input [P_DATA_WIDTH-1:0] B_DIN;
+input [P_DATA_WIDTH-1:0] B_BM;
+input                    B_WEN;
+input                    B_REN;
+
+//output port b
+output [P_DATA_WIDTH-1:0] B_DOUT;
+
+input                    B_BIST_EN;
+input [P_ADDR_WIDTH-1:0] B_BIST_ADDR;
+input [P_DATA_WIDTH-1:0] B_BIST_DIN;
+input [P_DATA_WIDTH-1:0] B_BIST_BM;
+input                    B_BIST_MEN;
+input                    B_BIST_WEN;
+input                    B_BIST_REN;
+input                    B_BIST_CLK;
+
+
+
+//memory array
+reg [P_DATA_WIDTH-1:0]    mem_arr [0:P_ADDR_COUNT-1];
+
+//real time_a;
+//real time_b;
+
+reg [P_DATA_WIDTH-1:0] dr_a_r;
+reg [P_DATA_WIDTH-1:0] dr_b_r;
+
+wire  [P_ADDR_WIDTH-1:0]	A_ADDR_MUX;
+wire  [P_DATA_WIDTH-1:0] 	A_DIN_MUX;
+wire  [P_DATA_WIDTH-1:0]	A_BM_MUX;
+wire                        A_MEN_MUX;
+wire                        A_WEN_MUX;
+wire                        A_REN_MUX;
+wire                        A_CLK_MUX;
+
+wire  [P_ADDR_WIDTH-1:0]	B_ADDR_MUX;
+wire  [P_DATA_WIDTH-1:0] 	B_DIN_MUX;
+wire  [P_DATA_WIDTH-1:0]	B_BM_MUX;
+wire                        B_MEN_MUX;
+wire                        B_WEN_MUX;
+wire                        B_REN_MUX;
+wire                        B_CLK_MUX;
+
+
+//BIST-MUX
+assign A_ADDR_MUX=(A_BIST_EN==1'b1)?A_BIST_ADDR:A_ADDR;
+assign A_DIN_MUX=(A_BIST_EN==1'b1)?A_BIST_DIN:A_DIN;
+assign A_BM_MUX=(A_BIST_EN==1'b1)?A_BIST_BM:A_BM;
+assign A_MEN_MUX=(A_BIST_EN==1'b1)?A_BIST_MEN:A_MEN;
+assign A_WEN_MUX=(A_BIST_EN==1'b1)?A_BIST_WEN:A_WEN;
+assign A_REN_MUX=(A_BIST_EN==1'b1)?A_BIST_REN:A_REN;
+assign A_CLK_MUX=(A_BIST_EN==1'b1)?A_BIST_CLK:A_CLK;
+
+assign B_ADDR_MUX=(B_BIST_EN==1'b1)?B_BIST_ADDR:B_ADDR;
+assign B_DIN_MUX=(B_BIST_EN==1'b1)?B_BIST_DIN:B_DIN;
+assign B_BM_MUX=(B_BIST_EN==1'b1)?B_BIST_BM:B_BM;
+assign B_MEN_MUX=(B_BIST_EN==1'b1)?B_BIST_MEN:B_MEN;
+assign B_WEN_MUX=(B_BIST_EN==1'b1)?B_BIST_WEN:B_WEN;
+assign B_REN_MUX=(B_BIST_EN==1'b1)?B_BIST_REN:B_REN;
+assign B_CLK_MUX=(B_BIST_EN==1'b1)?B_BIST_CLK:B_CLK;
+
+
+always @(posedge A_CLK_MUX) begin
+    //time_a=$realtime;
+    if(A_MEN_MUX==1'b1 && A_WEN_MUX==1'b1) begin
+        mem_arr[A_ADDR_MUX] <= (mem_arr[A_ADDR_MUX] & ~A_BM_MUX) | (A_DIN_MUX & A_BM_MUX);
+        if (A_REN_MUX==1'b1) begin
+            dr_a_r<= (mem_arr[A_ADDR_MUX] & ~A_BM_MUX) | (A_DIN_MUX & A_BM_MUX);
+        end
+    end
+    else if(A_MEN_MUX==1'b1 && A_REN_MUX==1'b1) begin
+        dr_a_r<=mem_arr[A_ADDR_MUX];
+    end
+end
+
+
+always @(posedge B_CLK_MUX) begin
+    //time_b=$realtime;
+    if(B_MEN_MUX==1'b1 && B_WEN_MUX==1'b1) begin
+        mem_arr[B_ADDR_MUX] <= (mem_arr[B_ADDR_MUX] & ~B_BM_MUX) | (B_DIN_MUX & B_BM_MUX);
+        if (B_REN_MUX==1'b1) begin
+            dr_b_r<= (mem_arr[B_ADDR_MUX] & ~B_BM_MUX) | (B_DIN_MUX & B_BM_MUX);
+        end
+    end
+    else if(B_MEN_MUX==1'b1 && B_REN_MUX==1'b1) begin
+        dr_b_r<=mem_arr[B_ADDR_MUX];
+    end
+end
+
+assign A_DOUT=  dr_a_r;
+assign B_DOUT=  dr_b_r;
+
+
+endmodule

--- a/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_core_behavioral_ideal.v
+++ b/src/main/scala/vexriscv/ihp/sg13g2/RM_IHPSG13_2P_core_behavioral_ideal.v
@@ -1,0 +1,149 @@
+// ------------------------------------------------------
+//
+//		Copyright 2023 IHP PDK Authors
+//
+//		Licensed under the Apache License, Version 2.0 (the "License");
+//		you may not use this file except in compliance with the License.
+//		You may obtain a copy of the License at
+//
+//		   https://www.apache.org/licenses/LICENSE-2.0
+//
+//		Unless required by applicable law or agreed to in writing, software
+//		distributed under the License is distributed on an "AS IS" BASIS,
+//		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//		See the License for the specific language governing permissions and
+//		limitations under the License.
+//
+//		Generated on Thu Jun 12 11:08:49 2025
+//
+// ------------------------------------------------------
+module SRAM_2P_behavioral(//inputs port
+                          A_CLK,
+                          A_DLY,
+                          A_MEN,
+                          A_ADDR,
+                          A_DIN,
+                          A_WEN,
+                          A_REN,
+
+                          //output port a
+                          A_DOUT,
+
+                          //inputs port b
+                          B_CLK,
+                          B_DLY,
+                          B_MEN,
+                          B_ADDR,
+                          B_DIN,
+                          B_WEN,
+                          B_REN,
+
+                          //output port b
+                          B_DOUT);
+
+
+
+parameter P_DATA_WIDTH =  20;
+parameter P_ADDR_WIDTH =  9;
+
+parameter P_ADDR_COUNT = 2**P_ADDR_WIDTH; //2^P_ADDR_WIDTH
+
+parameter      P_FORCE_ERROR    = 0;
+parameter [P_ADDR_WIDTH:0]    P_ERROR_ADDR    = 50;
+parameter [P_DATA_WIDTH-1:0]  P_ERROR_PATTERN     = 40'h0000000000;
+
+//inputs port a
+input                    A_CLK;
+input                    A_DLY;
+input                    A_MEN;
+input [P_ADDR_WIDTH-1:0] A_ADDR;
+input [P_DATA_WIDTH-1:0] A_DIN;
+input                    A_WEN;
+input                    A_REN;
+
+//output port a
+output [P_DATA_WIDTH-1:0] A_DOUT;
+
+
+//inputs port b
+input                    B_CLK;
+input                    B_DLY;
+input                    B_MEN;
+input [P_ADDR_WIDTH-1:0] B_ADDR;
+input [P_DATA_WIDTH-1:0] B_DIN;
+input                    B_WEN;
+input                    B_REN;
+
+//output port b
+output [P_DATA_WIDTH-1:0] B_DOUT;
+
+
+
+//memory array
+reg [P_DATA_WIDTH-1:0]    mem_arr [0:P_ADDR_COUNT-1];
+
+reg [P_DATA_WIDTH-1:0] dr_a_r;
+reg [P_DATA_WIDTH-1:0] dr_b_r;
+
+wire  [P_ADDR_WIDTH-1:0]	A_ADDR_MUX;
+wire  [P_DATA_WIDTH-1:0] 	A_DIN_MUX;
+wire                        A_MEN_MUX;
+wire                        A_WEN_MUX;
+wire                        A_REN_MUX;
+wire                        A_CLK_MUX;
+
+wire  [P_ADDR_WIDTH-1:0]	B_ADDR_MUX;
+wire  [P_DATA_WIDTH-1:0] 	B_DIN_MUX;
+wire  [P_DATA_WIDTH-1:0]	B_BM_MUX;
+wire                        B_MEN_MUX;
+wire                        B_WEN_MUX;
+wire                        B_REN_MUX;
+wire                        B_CLK_MUX;
+
+
+//BIST-MUX
+assign A_ADDR_MUX=A_ADDR;
+assign A_DIN_MUX=A_DIN;
+assign A_MEN_MUX=A_MEN;
+assign A_WEN_MUX=A_WEN;
+assign A_REN_MUX=A_REN;
+assign A_CLK_MUX=A_CLK;
+
+assign B_ADDR_MUX=B_ADDR;
+assign B_DIN_MUX=B_DIN;
+assign B_MEN_MUX=B_MEN;
+assign B_WEN_MUX=B_WEN;
+assign B_REN_MUX=B_REN;
+assign B_CLK_MUX=B_CLK;
+
+
+always @(posedge A_CLK_MUX) begin
+    if(A_MEN_MUX==1'b1 && A_WEN_MUX==1'b1) begin
+        mem_arr[A_ADDR_MUX] <= A_DIN_MUX;
+        if (A_REN_MUX==1'b1) begin
+            dr_a_r<= A_DIN_MUX;
+        end
+    end
+    else if(A_MEN_MUX==1'b1 && A_REN_MUX==1'b1) begin
+        dr_a_r<=mem_arr[A_ADDR_MUX];
+    end
+end
+
+
+always @(posedge B_CLK_MUX) begin
+    if(B_MEN_MUX==1'b1 && B_WEN_MUX==1'b1) begin
+        mem_arr[B_ADDR_MUX] <= B_DIN_MUX;
+        if (B_REN_MUX==1'b1) begin
+            dr_b_r<= B_DIN_MUX;
+        end
+    end
+    else if(B_MEN_MUX==1'b1 && B_REN_MUX==1'b1) begin
+        dr_b_r<=mem_arr[B_ADDR_MUX];
+    end
+end
+
+assign A_DOUT=  dr_a_r;
+assign B_DOUT=  dr_b_r;
+
+
+endmodule

--- a/src/main/scala/vexriscv/ip/IhpInstructionCache.scala
+++ b/src/main/scala/vexriscv/ip/IhpInstructionCache.scala
@@ -1,0 +1,243 @@
+package vexriscv.ip
+
+import vexriscv._
+import vexriscv.ihp.sg13g2._
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.amba4.axi.{Axi4Config, Axi4ReadOnly}
+import spinal.lib.bus.avalon.{AvalonMM, AvalonMMConfig}
+import spinal.lib.bus.bmb.{Bmb, BmbAccessParameter, BmbParameter, BmbSourceParameter}
+import spinal.lib.bus.wishbone.{AddressGranularity, Wishbone, WishboneConfig}
+import spinal.lib.bus.simple._
+import vexriscv.plugin.{IBusSimpleBus, IBusSimplePlugin}
+
+
+class IhpInstructionCache(p : InstructionCacheConfig, mmuParameter : MemoryTranslatorBusParameter) extends Component with InstructionCacheIp{
+  import p._
+  val io = new Bundle{
+    val flush = in Bool()
+    val cpu = slave(InstructionCacheCpuBus(p, mmuParameter))
+    val mem = master(InstructionCacheMemBus(p))
+  }
+
+  val lineWidth = bytePerLine*8
+  val lineCount = cacheSize/bytePerLine
+  val cpuWordWidth = cpuDataWidth
+  val memWordPerLine = lineWidth/memDataWidth
+  val bytePerCpuWord = cpuWordWidth/8
+  val wayLineCount = lineCount/wayCount
+
+  val tagRange = addressWidth-1 downto log2Up(wayLineCount*bytePerLine)
+  val lineRange = tagRange.low-1 downto log2Up(bytePerLine)
+
+  case class LineTagNoAddr() extends Bundle {
+    val valid = Bool
+    val error = Bool
+  }
+
+  case class LineTag() extends Bundle{
+    val valid = Bool
+    val error = Bool
+    val address = UInt(tagRange.length bit)
+  }
+
+  val bankCount = wayCount
+  val bankWidth = if(!reducedBankWidth) memDataWidth else Math.max(cpuDataWidth, memDataWidth/wayCount)
+  val bankByteSize = cacheSize/bankCount
+  val bankWordCount = bankByteSize*8/bankWidth
+  val bankWordToCpuWordRange = log2Up(bankWidth/8)-1 downto log2Up(bytePerCpuWord)
+  val memToBankRatio = bankWidth*bankCount / memDataWidth
+
+  val banks = Seq.fill(bankCount)(new Area {
+    val bank = Memory(memDataWidth, cacheSize)
+    bank.connectDefaults()
+    bank.A_MEN := True
+    bank.A_REN := False
+    bank.B_MEN := True
+    bank.B_WEN := False
+    bank.B_DIN := B(0)
+  })
+
+  val ways = Seq.fill(wayCount)(new Area{
+    val tags = Mem(LineTagNoAddr(), wayLineCount)
+    val addr = Memory(22, cacheSize)
+    addr.connectDefaults()
+    addr.A_ADDR := io.cpu.prefetch.pc(lineRange).asBits
+    addr.A_MEN := True
+    addr.A_REN := True
+    addr.A_DIN := B(0)
+    addr.A_WEN := False
+    addr.B_MEN := True
+    addr.B_REN := False
+
+    if(preResetFlush){
+      tags.initBigInt(List.fill(wayLineCount)(BigInt(0)))
+    }
+  })
+
+
+  val lineLoader = new Area{
+    val fire = False
+    val valid = RegInit(False) clearWhen(fire)
+    val lock = RegInit(True) clearWhen(io.mem.cmd.fire)
+    val address = KeepAttribute(Reg(UInt(addressWidth bits)))
+    val hadError = RegInit(False) clearWhen(fire)
+    val flushPending = RegInit(True)
+
+    when(io.cpu.fill.valid){
+      valid := True
+      address := io.cpu.fill.payload
+    }
+
+    io.cpu.prefetch.haltIt := valid || flushPending
+
+    val flushCounter = Reg(UInt(log2Up(wayLineCount) + 1 bit))
+    when(!flushCounter.msb){
+      io.cpu.prefetch.haltIt := True
+      flushCounter := flushCounter + 1
+    }
+    when(!RegNext(flushCounter.msb)){
+      io.cpu.prefetch.haltIt := True
+    }
+
+    when(io.flush){
+      io.cpu.prefetch.haltIt := True
+      flushPending := True
+    }
+
+    when(flushPending && !(valid || io.cpu.fetch.isValid) ){
+      flushCounter := 0
+      flushPending := False
+    }
+
+    val cmdSent = RegInit(False) setWhen(io.mem.cmd.fire) clearWhen(fire)
+    io.mem.cmd.valid := valid && !cmdSent
+    io.mem.cmd.address := address(tagRange.high downto lineRange.low) @@ U(0,lineRange.low bit)
+    io.mem.cmd.size := log2Up(p.bytePerLine)
+
+    val wayToAllocate = Counter(wayCount, !valid)
+    val wordIndex = KeepAttribute(Reg(UInt(log2Up(memWordPerLine) bits)) init(0))
+
+    val write = new Area{
+      val tag = ways.map(_.tags.writePort)
+    }
+
+    for(wayId <- 0 until wayCount) {
+      val wayHit = wayToAllocate === wayId
+      val tag = write.tag(wayId)
+      tag.valid := ((wayHit && fire) || !flushCounter.msb)
+      tag.address := (flushCounter.msb ? address(lineRange) | flushCounter(flushCounter.high-1 downto 0))
+      tag.data.valid := flushCounter.msb
+      tag.data.error := hadError || io.mem.rsp.error
+      val addr = ways(wayId).addr
+      addr.B_ADDR := (flushCounter.msb ? address(lineRange) | flushCounter(flushCounter.high-1 downto 0)).asBits
+      addr.B_WEN := ((wayHit && fire) || !flushCounter.msb)
+      addr.B_DIN := address(tagRange).asBits // TODO
+    }
+
+    for((writeBank, bankId) <- banks.zipWithIndex){
+      if(!reducedBankWidth) {
+        writeBank.bank.A_WEN := io.mem.rsp.valid && wayToAllocate === bankId
+        writeBank.bank.A_ADDR := (address(lineRange) @@ wordIndex).asBits.resized
+        writeBank.bank.A_DIN := io.mem.rsp.data
+      } else {
+        val sel = U(bankId) - wayToAllocate.value
+        val groupSel = wayToAllocate(log2Up(bankCount)-1 downto log2Up(bankCount/memToBankRatio))
+        val subSel = sel(log2Up(bankCount/memToBankRatio) -1 downto 0)
+        writeBank.bank.A_WEN := io.mem.rsp.valid && groupSel === (bankId >> log2Up(bankCount/memToBankRatio))
+        writeBank.bank.A_ADDR := (address(lineRange) @@ wordIndex @@ (subSel)).asBits
+        writeBank.bank.A_DIN := io.mem.rsp.data.subdivideIn(bankCount/memToBankRatio slices)(subSel)
+      }
+    }
+
+    when(io.mem.rsp.valid && !lock) {
+      wordIndex := (wordIndex + 1).resized
+      hadError.setWhen(io.mem.rsp.error)
+      when(wordIndex === wordIndex.maxValue) {
+        fire := True
+      }
+    }
+  }
+
+  val fetchStage = new Area{
+    val read = new Area{
+      val banksValue = for(readBank <- banks) yield new Area{
+        readBank.bank.B_REN := !io.cpu.fetch.isStuck
+        readBank.bank.B_ADDR := io.cpu.prefetch.pc(lineRange.high downto log2Up(bankWidth/8)).asBits
+        val dataMem = readBank.bank.B_DOUT
+        val data = if(!twoCycleRamInnerMux) dataMem.subdivideIn(cpuDataWidth bits).read(io.cpu.fetch.pc(bankWordToCpuWordRange)) else dataMem
+      }
+
+      val waysValues = for((way, wayId) <- ways.zipWithIndex) yield new Area{
+        val tag = new LineTag()
+        if(asyncTagMemory) {
+          tag.valid := way.tags.readAsync(io.cpu.fetch.pc(lineRange)).valid
+          tag.error := way.tags.readAsync(io.cpu.fetch.pc(lineRange)).error
+        } else {
+          tag.valid := way.tags.readSync(io.cpu.prefetch.pc(lineRange), !io.cpu.fetch.isStuck).valid
+          tag.error := way.tags.readSync(io.cpu.prefetch.pc(lineRange), !io.cpu.fetch.isStuck).error
+        }
+        tag.address := way.addr.A_DOUT(21 downto 0).asUInt.resized
+      }
+    }
+
+    val hit = (!twoCycleRam) generate new Area{
+      val hits = read.waysValues.map(way => way.tag.valid && way.tag.address === io.cpu.fetch.mmuRsp.physicalAddress(tagRange))
+      val valid = Cat(hits).orR
+      val wayId = OHToUInt(hits)
+      val bankId = if(!reducedBankWidth) wayId else (wayId >> log2Up(bankCount/memToBankRatio)) @@ ((wayId + (io.cpu.fetch.mmuRsp.physicalAddress(log2Up(bankWidth/8), log2Up(bankCount) bits))).resize(log2Up(bankCount/memToBankRatio)))
+      val error = read.waysValues.map(_.tag.error).read(wayId)
+      val data = read.banksValue.map(_.data).read(bankId)
+      val word = if(cpuDataWidth == memDataWidth || !twoCycleRamInnerMux) CombInit(data) else data.subdivideIn(cpuDataWidth bits).read(io.cpu.fetch.pc(bankWordToCpuWordRange))
+      io.cpu.fetch.data := (if(p.bypassGen) (io.cpu.fetch.dataBypassValid ? io.cpu.fetch.dataBypass | word) else word)
+      if(twoCycleCache){
+        io.cpu.decode.data := RegNextWhen(io.cpu.fetch.data,!io.cpu.decode.isStuck)
+      }
+    }
+
+    if(twoCycleRam && wayCount == 1){
+      val cacheData = if(cpuDataWidth == memDataWidth || !twoCycleRamInnerMux) CombInit(read.banksValue.head.data) else read.banksValue.head.data.subdivideIn(cpuDataWidth bits).read(io.cpu.fetch.pc(bankWordToCpuWordRange))
+      io.cpu.fetch.data := (if(p.bypassGen) (io.cpu.fetch.dataBypassValid ? io.cpu.fetch.dataBypass | cacheData) else cacheData)
+    }
+
+    io.cpu.fetch.physicalAddress := io.cpu.fetch.mmuRsp.physicalAddress
+
+    val resolution = ifGen(!twoCycleCache)( new Area{
+      val mmuRsp = io.cpu.fetch.mmuRsp
+
+      io.cpu.fetch.cacheMiss := !hit.valid
+      io.cpu.fetch.error := hit.error || (!mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute))
+      io.cpu.fetch.mmuRefilling := mmuRsp.refilling
+      io.cpu.fetch.mmuException := !mmuRsp.refilling && mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute)
+    })
+  }
+
+  val decodeStage = ifGen(twoCycleCache) (new Area{
+    def stage[T <: Data](that : T) = RegNextWhen(that, !io.cpu.decode.isStuck)
+    val mmuRsp = stage(io.cpu.fetch.mmuRsp)
+
+    val hit = if(!twoCycleRam) new Area{
+      val valid = stage(fetchStage.hit.valid)
+      val error = stage(fetchStage.hit.error)
+    } else new Area{
+      val tags = fetchStage.read.waysValues.map(way => stage(way.tag))
+      val hits = tags.map(tag => tag.valid && tag.address === mmuRsp.physicalAddress(tagRange))
+      val valid = Cat(hits).orR
+      val wayId = OHToUInt(hits)
+      val bankId = if(!reducedBankWidth) wayId else (wayId >> log2Up(bankCount/memToBankRatio)) @@ ((wayId + (mmuRsp.physicalAddress(log2Up(bankWidth/8), log2Up(bankCount) bits))).resize(log2Up(bankCount/memToBankRatio)))
+      val error = tags(wayId).error
+      val data = fetchStage.read.banksValue.map(bank => stage(bank.data)).read(bankId)
+      val word = if(cpuDataWidth == memDataWidth || !twoCycleRamInnerMux) data else data.subdivideIn(cpuDataWidth bits).read(io.cpu.decode.pc(bankWordToCpuWordRange))
+      if(p.bypassGen) when(stage(io.cpu.fetch.dataBypassValid)){
+        word := stage(io.cpu.fetch.dataBypass)
+      }
+      io.cpu.decode.data := word
+    }
+
+    io.cpu.decode.cacheMiss := !hit.valid
+    io.cpu.decode.error := hit.error || (!mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute))
+    io.cpu.decode.mmuRefilling := mmuRsp.refilling
+    io.cpu.decode.mmuException := !mmuRsp.refilling && mmuRsp.isPaging && (mmuRsp.exception || !mmuRsp.allowExecute)
+    io.cpu.decode.physicalAddress := mmuRsp.physicalAddress
+  })
+}


### PR DESCRIPTION
Add 1kB data and instruction caches with sram macros for the IHP SG13G2 technology.

---

- [x] Add more `required` to prevent invalid configs
- [ ] Remove unsupported configs for IHP cache IPs.