### PR TITLE
Bugfix: make AXI4Shared preserve ARSIZE/AWSIZE

### DIFF
--- a/src/main/scala/vexriscv/ip/DataCache.scala
+++ b/src/main/scala/vexriscv/ip/DataCache.scala
@@ -299,7 +299,8 @@ case class DataCacheMemBus(p : DataCacheConfig) extends Bundle with IMasterSlave
     axi.sharedCmd.write := cmdStage.wr
     axi.sharedCmd.prot := "010"
     axi.sharedCmd.cache := "1111"
-    axi.sharedCmd.size := log2Up(p.memDataBytes)
+    axi.sharedCmd.size :=
+      cmdStage.uncached ? cmdStage.size.resized | U(log2Up(p.memDataBytes), axi.sharedCmd.size.getWidth bits)
     axi.sharedCmd.addr := cmdStage.address
     axi.sharedCmd.len  := cmdStage.beatCountMinusOne.resized
 


### PR DESCRIPTION
The error showed up in a setup with 64-bit bus (D extension)

DataCache.scala includes handling for both cached and uncached access. Currently, in toAxi4Shared() the size is hardwired to:

    axi.sharedCmd.size := log2Up(p.memDataBytes)

That makes all uncached/MMIO accesses with AxSIZE=3 (64 bits) in a 64-bit bus, which is problematic for peripherals that don't support 64-bit accesses.

The change preserves MMIO/uncached access size:

    Byte access       -> AXI SIZE=0
    Half word access  -> AXI SIZE=1
    Word access       -> AXI SIZE=2
    FLD/FSD (float)   -> AXI SIZE=3

While for cached memory/cache refills it keeps using full bus width. E.g.
    AxSIZE=3 for 64-bit bus