### PR TITLE
Add SWD debug transport to the SMP cluster

### DIFF
--- a/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
+++ b/src/main/scala/vexriscv/demo/smp/VexRiscvSmpCluster.scala
@@ -14,7 +14,7 @@ import spinal.lib.com.jtag.xilinx.Bscane2BmbMasterGenerator
 import spinal.lib.generator._
 import spinal.core.fiber._
 import spinal.idslplugin.PostInitCallback
-import spinal.lib.cpu.riscv.debug.{DebugModule, DebugModuleCpuConfig, DebugModuleParameter, DebugTransportModuleJtagTap, DebugTransportModuleJtagTapWithTunnel, DebugTransportModuleParameter, DebugTransportModuleTunneled}
+import spinal.lib.cpu.riscv.debug.{DebugModule, DebugModuleCpuConfig, DebugModuleParameter, DebugTransportModuleJtagTap, DebugTransportModuleJtagTapWithTunnel, DebugTransportModuleParameter, DebugTransportModuleSwd, DebugTransportModuleTunneled}
 import spinal.lib.misc.plic.PlicMapping
 import spinal.lib.system.debugger.SystemDebuggerConfig
 import vexriscv.ip.{DataCacheAck, DataCacheConfig, DataCacheMemBus, InstructionCache, InstructionCacheConfig}
@@ -35,8 +35,12 @@ case class VexRiscvSmpClusterParameter(cpuConfigs : Seq[VexRiscvConfig],
                                        privilegedDebug : Boolean = false,
                                        hardwareBreakpoints : Int = 0,
                                        jtagTap : Boolean = false,
-                                       interruptCount : Int = 32
-                                      )
+                                       interruptCount : Int = 32,
+                                       swd : Boolean = false){
+  // One transport per DebugBus: JTAG DTM and SWD DTM cannot both drive dm.io.ctrl.
+  assert(!(swd && jtagTap), "VexRiscvSmpCluster: swd and jtagTap are mutually exclusive (single DebugBus, no arbitration)")
+  assert(!swd || privilegedDebug, "VexRiscvSmpCluster: swd requires privilegedDebug (official RISC-V DM only)")
+}
 
 class VexRiscvSmpClusterBase(p : VexRiscvSmpClusterParameter) extends Area with PostInitCallback{
   val cpuCount = p.cpuConfigs.size
@@ -138,7 +142,7 @@ class VexRiscvSmpClusterBase(p : VexRiscvSmpClusterParameter) extends Area with 
 
       val clintStop =  (cores.map(e => e.cpu.logic.cpu.service(classOf[CsrPlugin]).stoptime).andR)
 
-      val noTap = !p.jtagTap generate new Area {
+      val noTap = (!p.jtagTap && !p.swd) generate new Area {
         val jtagCd = ClockDomain.external("jtag", withReset = false)
 
         val tunnel = DebugTransportModuleTunneled(
@@ -157,6 +161,26 @@ class VexRiscvSmpClusterBase(p : VexRiscvSmpClusterParameter) extends Area with 
         )
         dm.io.ctrl <> tunnel.io.bus
         val debugPort = Handle(tunnel.io.jtag.toIo).setName("debugPort")
+      }
+
+      // SWD transport: SWCLK/SWDIO replace the JTAG DTM entirely (mutually exclusive with
+      // noTap/withTap above). SWDIO is exposed as three wires (i/o/oe) — the IOBUF belongs
+      // at the platform level, not inside this black box.
+      val withSwd = p.swd generate new Area {
+        val transport = DebugTransportModuleSwd(
+          p = dp,
+          debugCd = ClockDomain.current
+        )
+        dm.io.ctrl <> transport.io.bus
+        // Per-signal toIo: io.swd is an anonymous nested Bundle, so cloneOf (and therefore
+        // whole-bundle toIo) fails on it. Names are pinned explicitly because the LiteX
+        // black-box port map in vexriscv_smp/core.py depends on them.
+        val debugPort = Handle(new Area {
+          val swclk    = transport.io.swd.swclk    .toIo.setName("debugPort_swclk")
+          val swdio_i  = transport.io.swd.swdio.i  .toIo.setName("debugPort_swdio_i")
+          val swdio_o  = transport.io.swd.swdio.o  .toIo.setName("debugPort_swdio_o")
+          val swdio_oe = transport.io.swd.swdio.oe .toIo.setName("debugPort_swdio_oe")
+        })
       }
     })
   }

--- a/src/main/scala/vexriscv/demo/smp/VexRiscvSmpLitexCluster.scala
+++ b/src/main/scala/vexriscv/demo/smp/VexRiscvSmpLitexCluster.scala
@@ -116,6 +116,7 @@ object VexRiscvLitexSmpClusterCmdGen extends App {
   var dCacheWays = 2
   var privilegedDebug = false
   var jtagTap = false
+  var swd = false
   var hardwareBreakpoints = 0
   var interruptCount = 32
   var liteDramWidth = 128
@@ -146,6 +147,7 @@ object VexRiscvLitexSmpClusterCmdGen extends App {
     opt[String]("dcache-ways") action { (v, c) => dCacheWays = v.toInt }
     opt[Boolean]("privileged-debug") action { (v, c) => privilegedDebug = v }
     opt[Boolean]("jtag-tap") action { (v, c) => jtagTap = v }
+    opt[Boolean]("swd") action { (v, c) => swd = v }
     opt[Int]   ("hardware-breakpoints") action { (v, c) => hardwareBreakpoints = v }
     opt[Int]   ("interrupt-count") action { (v, c) => interruptCount = v }
     opt[String]("litedram-width") action { (v, c) => liteDramWidth = v.toInt }
@@ -200,7 +202,8 @@ object VexRiscvLitexSmpClusterCmdGen extends App {
       jtagHeaderIgnoreWidth = 0,
       privilegedDebug = privilegedDebug,
       hardwareBreakpoints = hardwareBreakpoints,
-      jtagTap = jtagTap
+      jtagTap = jtagTap,
+      swd = swd
     ),
     liteDram = LiteDramNativeParameter(addressWidth = 32, dataWidth = liteDramWidth),
     liteDramMapping = SizeMapping(0x40000000l, 0x40000000l),

--- a/src/test/scala/vexriscv/DebugSwdDmTest.scala
+++ b/src/test/scala/vexriscv/DebugSwdDmTest.scala
@@ -1,0 +1,196 @@
+package vexriscv
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.cpu.riscv.debug._
+
+/**
+ * Two truly asynchronous clocks: the bench bit-bangs SWCLK through SwdHostDriver while
+ * the debug domain free-runs via forkStimulus. DMI completions therefore take a variable
+ * number of SWCLK cycles — the helpers retry on WAIT exactly like a host would.
+ *
+ * Run: sbt "testOnly vexriscv.DebugSwdDmTest"
+ */
+
+case class SwdDmTestTop(dpidr : BigInt, apIdr : BigInt) extends Component {
+  val p = DebugTransportModuleParameter(addressWidth = 7, version = 1, idle = 7)
+
+  val io = new Bundle {
+    val swclk = in Bool()
+    val swdio = new Bundle {
+      val i  = in  Bool()
+      val o  = out Bool()
+      val oe = out Bool()
+    }
+  }
+
+  val dm = DebugModule(DebugModuleParameter(
+    version     = p.version + 1,
+    harts       = 1,
+    progBufSize = 2,
+    datacount   = 1,
+    hartsConfig = List(DebugModuleCpuConfig(xlen = 32, flen = 0, withFpuRegAccess = false))
+  ))
+
+  // Stubbed hart: never halted, always running, never resets (step 2 needs no CPU).
+  val hart = dm.io.harts(0)
+  hart.halted      := False
+  hart.running     := True
+  hart.unavailable := False
+  hart.haveReset   := False
+  hart.exception   := False
+  hart.commit      := False
+  hart.ebreak      := False
+  hart.redo        := False
+  hart.regSuccess  := False
+  hart.hartToDm.setIdle()
+  hart.resume.rsp.setIdle()
+
+  val transport = DebugTransportModuleSwd(
+    p = p, debugCd = ClockDomain.current, dpidr = dpidr, apIdr = apIdr)
+  transport.io.swd.swclk   := io.swclk
+  transport.io.swd.swdio.i := io.swdio.i
+  io.swdio.o  := transport.io.swd.swdio.o
+  io.swdio.oe := transport.io.swd.swdio.oe
+
+  dm.io.ctrl <> transport.io.bus
+}
+
+class DebugSwdDmTest extends AnyFunSuite {
+  import SwdAckSim._
+
+  val DPIDR  = BigInt("0BA11AAB", 16)
+  val AP_IDR = BigInt("74726976", 16)
+
+  lazy val compiled = SimConfig.compile(SwdDmTestTop(DPIDR, AP_IDR))
+
+  class Harness(val dut: SwdDmTestTop) {
+    val swdCd = ClockDomain(dut.io.swclk)
+    val drv = new SwdHostDriver(swdCd, dut.io.swdio.i, dut.io.swdio.o, dut.io.swdio.oe)
+
+    def start(): Unit = {
+      dut.io.swclk #= false
+      dut.io.swdio.i #= false
+      dut.clockDomain.forkStimulus(period = 10)   // free-running async debug domain
+      dut.clockDomain.waitSampling(10)            // let its reset deassert
+    }
+
+    def dpRead(addr: Int): (Int, Option[BigInt]) = drv.transactRead(apNdp = false, addr)
+
+    /** On an unexpected ACK, report CTRL/STAT so the guilty sticky flag is visible. */
+    def ackCheck(ack: Int, what: String): Unit = {
+      if (ack != WAIT) {
+        val (a, d) = dpRead(1)
+        val cs = if (a == OK) s"CTRL/STAT=0x${d.get.toString(16)}" else s"CTRL/STAT unreadable ack=$a"
+        throw new AssertionError(s"unexpected ack=$ack on $what ($cs)")
+      }
+    }
+
+    /** Poll RDBUFF until the outstanding DMI access completes; returns the result. */
+    def rdbuff(max: Int = 100): BigInt = {
+      var tries = 0
+      while (tries < max) {
+        val (ack, data) = dpRead(3)
+        if (ack == OK) return data.get
+        ackCheck(ack, "RDBUFF poll")
+        tries += 1
+        drv.idle(2)
+      }
+      throw new AssertionError("RDBUFF never completed")
+    }
+
+    /** AP write with host-style WAIT retry (the previous access may still be in flight). */
+    def apWriteRetry(addr: Int, data: BigInt, max: Int = 100): Unit = {
+      var tries = 0
+      while (tries < max) {
+        val ack = drv.transactWrite(apNdp = true, addr, data)
+        if (ack == OK) return
+        ackCheck(ack, s"AP write @$addr")
+        tries += 1
+        drv.idle(2)
+      }
+      throw new AssertionError("AP write never accepted")
+    }
+
+    /** AP read launch with WAIT retry (posted data returned by OK reads is stale). */
+    def apReadRetry(addr: Int, max: Int = 100): Unit = {
+      var tries = 0
+      while (tries < max) {
+        val (ack, _) = drv.transactRead(apNdp = true, addr)
+        if (ack == OK) return
+        ackCheck(ack, s"AP read @$addr")
+        tries += 1
+        drv.idle(2)
+      }
+      throw new AssertionError("AP read never accepted")
+    }
+
+    def dmiRead(dmiAddr: Int): BigInt = {
+      apWriteRetry(1, dmiAddr)                    // DMI_ADDR
+      apReadRetry(2)                              // launch DMI_DATA read (posted)
+      rdbuff()                                    // collect the completed result
+    }
+
+    def dmiWrite(dmiAddr: Int, data: BigInt): Unit = {
+      apWriteRetry(1, dmiAddr)
+      apWriteRetry(2, data)                       // completion covered by later retries
+    }
+  }
+
+  def sim(name: String, seed: Int = -1)(body: Harness => Unit): Unit = test(name) {
+    def run(dut: SwdDmTestTop): Unit = {
+      val h = new Harness(dut)
+      h.start()
+      h.drv.idle(4)                               // BOOT state RESET_WAIT -> IDLE
+      body(h)
+    }
+    if (seed >= 0) compiled.doSim(name.replace(' ', '_'), seed)(run)
+    else compiled.doSim(name.replace(' ', '_'))(run)
+  }
+
+  sim("DPIDR reads through the assembled transport") { h =>
+    val (ack, data) = h.dpRead(0)
+    assert(ack == OK && data.contains(DPIDR))
+  }
+
+  sim("AP IDR via posted read") { h =>
+    h.apReadRetry(0)
+    assert(h.rdbuff() == AP_IDR)
+  }
+
+  sim("DMI_ADDR write and readback") { h =>
+    h.apWriteRetry(1, 0x11)
+    h.apReadRetry(1)
+    assert(h.rdbuff() == 0x11)
+  }
+
+  sim("dmstatus read over SWD - step 2 exit criterion") { h =>
+    val dmstatus = h.dmiRead(0x11)
+    assert((dmstatus & 0xF) == 2, s"dmstatus.version, got 0x${dmstatus.toString(16)}")
+    assert(((dmstatus >> 7) & 1) == 1, "dmstatus.authenticated must be set")
+  }
+
+  sim("dmcontrol dmactive write and readback over SWD") { h =>
+    assert((h.dmiRead(0x10) & 1) == 0, "dmactive must reset low")
+    h.dmiWrite(0x10, 1)
+    assert((h.dmiRead(0x10) & 1) == 1, "dmactive must read back set")
+  }
+
+  sim("abstractauto write and readback over SWD") { h =>
+    // Note: data0/progbuf cannot round-trip with a stubbed hart — DM writes forward to
+    // the hart and reads return the hart-written Mem (needs a CPU; later integration).
+    // abstractauto is a plain read/write DM register: WARL bits [0] and [17:16] here.
+    h.dmiWrite(0x10, 1)                           // dmactive
+    h.dmiWrite(0x18, BigInt("00030001", 16))
+    assert(h.dmiRead(0x18) == BigInt("00030001", 16))
+    h.dmiWrite(0x18, 0)
+    assert(h.dmiRead(0x18) == 0)
+  }
+
+  sim("POSTED_READ returns the last DMI read result") { h =>
+    val dmstatus = h.dmiRead(0x11)
+    h.apReadRetry(3)
+    assert(h.rdbuff() == dmstatus)
+  }
+}

--- a/src/test/scala/vexriscv/DebugSwdDpTest.scala
+++ b/src/test/scala/vexriscv/DebugSwdDpTest.scala
@@ -1,0 +1,166 @@
+package vexriscv
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.cpu.riscv.debug._
+
+import scala.collection.mutable
+
+/**
+ * Run: sbt "testOnly vexriscv.DebugSwdDpTest"
+ */
+class DebugSwdDpTest extends AnyFunSuite {
+  import SwdAckSim._
+
+  val DPIDR = BigInt("0BA11AAB", 16)              // matches the SwdDp default (placeholder)
+  val STICKYERR = BigInt(1) << 5
+  val WDATAERR  = BigInt(1) << 7
+  val PWR_REQ   = BigInt("50000000", 16)          // CDBGPWRUPREQ | CSYSPWRUPREQ
+  val PWR_ALL   = BigInt("F0000000", 16)          // REQs + mirrored ACKs
+
+  lazy val compiled = SimConfig.compile(SwdPhyDp(DPIDR))
+
+  class Harness(val dut: SwdPhyDp) {
+    val cd  = dut.clockDomain
+    val drv = new SwdHostDriver(cd, dut.io.swdio.i, dut.io.swdio.o, dut.io.swdio.oe)
+    val apCmds = mutable.Queue[(Boolean, Int, BigInt)]()   // (rnw, A[3:2], wdata)
+
+    def start(): Unit = {
+      dut.io.swdio.i #= false
+      dut.io.ap.rsp.valid #= false
+      dut.io.ap.rsp.payload.error #= false
+      dut.io.ap.rsp.payload.data #= 0
+      cd.assertReset()
+      for (_ <- 0 until 4) { cd.fallingEdge(); sleep(2); cd.risingEdge(); sleep(2) }
+      cd.deassertReset()
+      sleep(2)
+      fork {                                       // AP-side observer (record only)
+        while (true) {
+          cd.waitSampling()
+          if (dut.io.ap.cmd.valid.toBoolean) {
+            apCmds += ((dut.io.ap.cmd.payload.rnw.toBoolean,
+                        dut.io.ap.cmd.payload.addr.toInt,
+                        dut.io.ap.cmd.payload.wdata.toBigInt))
+          }
+        }
+      }
+    }
+
+    /** Complete the outstanding AP transaction (test-controlled latency). */
+    def apComplete(data: BigInt, error: Boolean = false): Unit = {
+      dut.io.ap.rsp.payload.data #= data
+      dut.io.ap.rsp.payload.error #= error
+      dut.io.ap.rsp.valid #= true
+      drv.idle(1)                                  // one SWCLK edge to deliver it
+      dut.io.ap.rsp.valid #= false
+    }
+
+    def dpRead(addr: Int): (Int, Option[BigInt]) = drv.transactRead(apNdp = false, addr)
+    def apRead(addr: Int): (Int, Option[BigInt]) = drv.transactRead(apNdp = true, addr)
+    def dpWrite(addr: Int, data: BigInt, flipDataParity: Boolean = false): Int =
+      drv.transactWrite(apNdp = false, addr, data, flipDataParity)
+    def apWrite(addr: Int, data: BigInt): Int = drv.transactWrite(apNdp = true, addr, data)
+  }
+
+  def sim(name: String)(body: Harness => Unit): Unit = test(name) {
+    compiled.doSim(name.replace(' ', '_')) { dut =>
+      val h = new Harness(dut)
+      h.start()
+      h.drv.idle(4)
+      body(h)
+    }
+  }
+
+  sim("DPIDR read returns the configured value") { h =>
+    val (ack, data) = h.dpRead(0)
+    assert(ack == OK && data.contains(DPIDR))
+  }
+
+  sim("CTRL STAT power-up requests mirror ACKs") { h =>
+    assert(h.dpRead(1) == ((OK, Some(BigInt(0)))))
+    assert(h.dpWrite(1, PWR_REQ) == OK)
+    val (ack, data) = h.dpRead(1)
+    assert(ack == OK && data.contains(PWR_ALL))
+  }
+
+  sim("SELECT DPBANKSEL banks CTRL STAT") { h =>
+    assert(h.dpWrite(1, PWR_REQ) == OK)
+    assert(h.dpWrite(2, 1) == OK)                       // SELECT.DPBANKSEL = 1
+    assert(h.dpRead(1) == ((OK, Some(BigInt(0)))))      // unimplemented bank: RAZ
+    assert(h.dpWrite(2, 0) == OK)                       // back to bank 0
+    val (ack, data) = h.dpRead(1)
+    assert(ack == OK && data.contains(PWR_ALL))
+  }
+
+  sim("AP read is posted and RDBUFF returns the completed result") { h =>
+    val (a1, d1) = h.apRead(1)
+    assert(a1 == OK && d1.contains(BigInt(0)))          // stale buffer on first posted read
+    h.drv.idle(1)
+    val c1 = h.apCmds.dequeue()
+    assert(c1._1 && c1._2 == 1, "AP read must be launched at the request")
+    h.apComplete(BigInt("DEADBEEF", 16))
+    val (a2, d2) = h.dpRead(3)                          // RDBUFF
+    assert(a2 == OK && d2.contains(BigInt("DEADBEEF", 16)))
+    val (a3, d3) = h.apRead(2)                          // posted: previous result again
+    assert(a3 == OK && d3.contains(BigInt("DEADBEEF", 16)))
+    h.apComplete(BigInt("11111111", 16))
+    val (a4, d4) = h.dpRead(3)
+    assert(a4 == OK && d4.contains(BigInt("11111111", 16)))
+  }
+
+  sim("WAIT while an AP access is outstanding but DP accesses stay OK") { h =>
+    assert(h.apRead(0)._1 == OK)                        // launches; no completion yet
+    assert(h.apRead(0)._1 == WAIT)
+    assert(h.dpRead(3)._1 == WAIT)                      // RDBUFF is gated too
+    assert(h.dpRead(1)._1 == OK)                        // CTRL/STAT poll still works
+    h.apComplete(BigInt("22222222", 16))
+    val (ack, data) = h.dpRead(3)
+    assert(ack == OK && data.contains(BigInt("22222222", 16)))
+  }
+
+  sim("AP completion error sets STICKYERR and FAULTs until ABORT clears") { h =>
+    assert(h.apRead(0)._1 == OK)
+    h.apComplete(0, error = true)                       // -> STICKYERR
+    assert(h.apRead(0)._1 == FAULT)
+    assert(h.dpRead(3)._1 == FAULT)                     // RDBUFF FAULTs too
+    val (ai, di) = h.dpRead(0)
+    assert(ai == OK && di.contains(DPIDR), "DP accesses must keep working under sticky")
+    val (ac, dc) = h.dpRead(1)
+    assert(ac == OK && (dc.get & STICKYERR) != 0)
+    assert(h.dpWrite(0, 4) == OK)                       // ABORT.STKERRCLR
+    assert((h.dpRead(1)._2.get & STICKYERR) == 0)
+    assert(h.apRead(0)._1 == OK)
+    h.apComplete(0)
+  }
+
+  sim("write data parity error sets WDATAERR and drops the commit") { h =>
+    assert(h.dpWrite(1, PWR_REQ, flipDataParity = true) == OK)   // ACK precedes WDATA
+    val (ack, data) = h.dpRead(1)
+    assert(ack == OK && data.contains(WDATAERR), "flag set, power bits NOT committed")
+    assert(h.apRead(0)._1 == FAULT)
+    assert(h.dpWrite(0, 8) == OK)                       // ABORT.WDERRCLR
+    assert(h.dpRead(1) == ((OK, Some(BigInt(0)))))
+    assert(h.apRead(0)._1 == OK)
+    h.apComplete(0)
+  }
+
+  sim("AP write commits after the data phase and holds busy until completion") { h =>
+    assert(h.apWrite(2, BigInt("CAFEBABE", 16)) == OK)
+    h.drv.idle(2)
+    val c = h.apCmds.dequeue()
+    assert(!c._1 && c._2 == 2 && c._3 == BigInt("CAFEBABE", 16))
+    assert(h.apRead(0)._1 == WAIT)                      // write still outstanding
+    h.apComplete(0)                                     // write completion (no data)
+    assert(h.apRead(0)._1 == OK)
+    h.apComplete(BigInt("33333333", 16))
+    assert(h.dpRead(3)._2.contains(BigInt("33333333", 16)))
+  }
+
+  sim("RESEND returns the same value as RDBUFF") { h =>
+    assert(h.apRead(0)._1 == OK)
+    h.apComplete(BigInt("A5A5A5A5", 16))
+    assert(h.dpRead(2)._2.contains(BigInt("A5A5A5A5", 16)))   // RESEND
+    assert(h.dpRead(3)._2.contains(BigInt("A5A5A5A5", 16)))   // RDBUFF
+  }
+}

--- a/src/test/scala/vexriscv/DebugSwdTest.scala
+++ b/src/test/scala/vexriscv/DebugSwdTest.scala
@@ -1,0 +1,176 @@
+package vexriscv
+
+import org.scalatest.funsuite.AnyFunSuite
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib.cpu.riscv.debug._
+
+import scala.collection.mutable
+
+/**
+ * Run: sbt "testOnly vexriscv.DebugSwdTest"
+ */
+class DebugSwdTest extends AnyFunSuite {
+  val ACK_OK    = SwdAckSim.OK
+  val ACK_WAIT  = SwdAckSim.WAIT
+  val ACK_FAULT = SwdAckSim.FAULT
+
+  lazy val compiled = SimConfig.compile(SwdPhy())
+
+  class Harness(val dut: SwdPhy) {
+    val cd  = dut.clockDomain
+    val drv = new SwdHostDriver(cd, dut.io.swdio.i, dut.io.swdio.o, dut.io.swdio.oe)
+
+    // Stub DP programming + observation
+    var stubAck   = ACK_OK
+    var stubRdata = BigInt(0)
+    val cmds = mutable.Queue[(Boolean, Boolean, Int)]()   // (apNdp, rnw, A[3:2])
+    val wrs  = mutable.Queue[(BigInt, Boolean)]()         // (data, parityOk)
+
+    def start(): Unit = {
+      dut.io.swdio.i #= false
+      dut.io.dp.rsp.valid #= false
+      dut.io.dp.rsp.payload.ack #= 0
+      dut.io.dp.rsp.payload.rdata #= 0
+      cd.assertReset()
+      for (_ <- 0 until 4) { cd.fallingEdge(); sleep(2); cd.risingEdge(); sleep(2) }
+      cd.deassertReset()
+      sleep(2)
+      // Always-ready DP model: the ADI contract requires the DP to answer within the
+      // turnaround cycle, so the stub holds its programmed response valid continuously
+      // (reacting to cmd from a sim thread is one clock too late by design).
+      fork {
+        while (true) {
+          cd.waitSampling()
+          dut.io.dp.rsp.valid #= true
+          dut.io.dp.rsp.payload.ack #= stubAck
+          dut.io.dp.rsp.payload.rdata #= stubRdata
+          if (dut.io.dp.cmd.valid.toBoolean) {
+            cmds += ((dut.io.dp.cmd.payload.apNdp.toBoolean,
+                      dut.io.dp.cmd.payload.rnw.toBoolean,
+                      dut.io.dp.cmd.payload.addr.toInt))
+          }
+          if (dut.io.dp.wr.valid.toBoolean) {
+            wrs += ((dut.io.dp.wr.payload.data.toBigInt,
+                     dut.io.dp.wr.payload.parityOk.toBoolean))
+          }
+        }
+      }
+    }
+
+    // Delegates so the test bodies read at protocol level
+    def step(bit: Boolean): (Boolean, Boolean) = drv.step(bit)
+    def idle(n: Int): Unit = drv.idle(n)
+    def ones(n: Int): Unit = drv.ones(n)
+    def lineReset(): Unit = drv.lineReset()
+    def header(apNdp: Boolean, rnw: Boolean, addr: Int,
+               flipParity: Boolean = false, badStop: Boolean = false, badPark: Boolean = false): Unit =
+      drv.header(apNdp, rnw, addr, flipParity, badStop, badPark)
+    def transactRead(apNdp: Boolean, addr: Int): (Int, Option[BigInt]) = drv.transactRead(apNdp, addr)
+    def transactWrite(apNdp: Boolean, addr: Int, data: BigInt, flipDataParity: Boolean = false): Int =
+      drv.transactWrite(apNdp, addr, data, flipDataParity)
+  }
+
+  def sim(name: String)(body: Harness => Unit): Unit = test(name) {
+    compiled.doSim(name.replace(' ', '_')) { dut =>
+      val h = new Harness(dut)
+      h.start()
+      h.idle(4)
+      body(h)
+    }
+  }
+
+  sim("write reaches stub bit-exact") { h =>
+    val ack = h.transactWrite(apNdp = false, addr = 2, data = BigInt("CAFE1234", 16))
+    assert(ack == ACK_OK)
+    h.idle(2)
+    assert(h.cmds.dequeue() == ((false, false, 2)))
+    val (d, pOk) = h.wrs.dequeue()
+    assert(d == BigInt("CAFE1234", 16) && pOk)
+  }
+
+  sim("read returns stub data bit-exact with parity") { h =>
+    h.stubRdata = BigInt("12345678", 16)
+    val (ack, data) = h.transactRead(apNdp = true, addr = 1)
+    assert(ack == ACK_OK)
+    assert(data.contains(BigInt("12345678", 16)))
+    assert(h.cmds.dequeue() == ((true, true, 1)))
+  }
+
+  sim("DPIDR smoke read") { h =>
+    h.stubRdata = BigInt("0BC12477", 16)            // stub stands in for the 2B DPIDR
+    val (ack, data) = h.transactRead(apNdp = false, addr = 0)
+    assert(ack == ACK_OK)
+    assert(data.contains(BigInt("0BC12477", 16)))
+    assert(h.cmds.dequeue() == ((false, true, 0)))
+  }
+
+  sim("header parity error silences target until line reset") { h =>
+    h.header(apNdp = false, rnw = true, addr = 0, flipParity = true)
+    for (_ <- 0 until 10) { val (_, oe) = h.step(false); assert(!oe) }
+    h.header(apNdp = false, rnw = true, addr = 0)   // good header, but still in error
+    for (_ <- 0 until 10) { val (_, oe) = h.step(false); assert(!oe) }
+    assert(h.cmds.isEmpty, "no request may reach the DP while in protocol error")
+    h.lineReset()
+    h.stubRdata = BigInt("55AA55AA", 16)
+    val (ack, data) = h.transactRead(apNdp = false, addr = 0)
+    assert(ack == ACK_OK && data.contains(BigInt("55AA55AA", 16)))
+  }
+
+  sim("stop bit error silences target until line reset") { h =>
+    h.header(apNdp = false, rnw = false, addr = 3, badStop = true)
+    for (_ <- 0 until 10) { val (_, oe) = h.step(false); assert(!oe) }
+    assert(h.cmds.isEmpty)
+    h.lineReset()
+    assert(h.transactWrite(apNdp = false, addr = 3, data = 7) == ACK_OK)
+  }
+
+  sim("WAIT and FAULT skip the data phase") { h =>
+    h.stubAck = ACK_WAIT
+    val (a1, d1) = h.transactRead(apNdp = true, addr = 3)
+    assert(a1 == ACK_WAIT && d1.isEmpty)
+    assert(h.transactWrite(apNdp = true, addr = 3, data = 1) == ACK_WAIT)
+    h.stubAck = ACK_FAULT
+    val (a2, d2) = h.transactRead(apNdp = true, addr = 3)
+    assert(a2 == ACK_FAULT && d2.isEmpty)
+    h.stubAck = ACK_OK
+    h.stubRdata = 42
+    val (a3, d3) = h.transactRead(apNdp = true, addr = 3)
+    assert(a3 == ACK_OK && d3.contains(BigInt(42)))
+    h.idle(2)
+    assert(h.cmds.size == 4 && h.wrs.isEmpty)
+  }
+
+  sim("back-to-back transactions without idle cycles") { h =>
+    h.stubRdata = BigInt("A5A5A5A5", 16)
+    assert(h.transactWrite(apNdp = false, addr = 1, data = BigInt("DEADBEEF", 16)) == ACK_OK)
+    val (ack, data) = h.transactRead(apNdp = false, addr = 1)   // header starts immediately
+    assert(ack == ACK_OK && data.contains(BigInt("A5A5A5A5", 16)))
+    h.idle(2)
+    assert(h.wrs.dequeue()._1 == BigInt("DEADBEEF", 16))
+  }
+
+  sim("write data parity error is flagged and recoverable") { h =>
+    assert(h.transactWrite(apNdp = false, addr = 0, data = BigInt("00FF00FF", 16),
+                           flipDataParity = true) == ACK_OK)
+    h.idle(2)
+    val (d, pOk) = h.wrs.dequeue()
+    assert(d == BigInt("00FF00FF", 16) && !pOk, "commit must carry parityOk=false")
+    h.stubRdata = 3
+    val (ack, data) = h.transactRead(apNdp = false, addr = 0)   // no line reset needed
+    assert(ack == ACK_OK && data.contains(BigInt(3)))
+  }
+
+  sim("49 high cycles are not a line reset, 50 are") { h =>
+    h.header(apNdp = false, rnw = true, addr = 0, flipParity = true)   // enter error
+    h.idle(2)                       // break the run of 1s ending in the park bit
+    h.ones(49); h.idle(2)
+    h.header(apNdp = false, rnw = true, addr = 0)
+    for (_ <- 0 until 10) { val (_, oe) = h.step(false); assert(!oe) }
+    assert(h.cmds.isEmpty, "49 high cycles must not reset the line state")
+    h.ones(50); h.idle(2)
+    h.stubRdata = 9
+    val (ack, data) = h.transactRead(apNdp = false, addr = 0)
+    assert(ack == ACK_OK && data.contains(BigInt(9)))
+  }
+}

--- a/src/test/scala/vexriscv/SwdSimDriver.scala
+++ b/src/test/scala/vexriscv/SwdSimDriver.scala
@@ -1,0 +1,117 @@
+package vexriscv
+
+import spinal.core.{Bool, ClockDomain}
+import spinal.core.sim._
+
+/** ACK codes as read LSB-first off the wire (= the ADI register values). */
+object SwdAckSim {
+  val OK    = 1
+  val WAIT  = 2
+  val FAULT = 4
+}
+
+/**
+ *
+ * The bench owns SWCLK (the DUT clock) and reproduces OpenOCD's bitbang model: the host
+ * sets SWDIO while SWCLK is low and samples target data while low; the target acts on
+ * rising edges. All values are sent/collected LSB first. Protocol assertions (turnaround
+ * positions, no-drive during requests, read parity, WAIT/FAULT data-phase skip) are
+ * embedded in the transaction helpers.
+ */
+class SwdHostDriver(cd: ClockDomain, swdioI: Bool, swdioO: Bool, swdioOe: Bool) {
+  import SwdAckSim._
+
+  /** One SWCLK cycle. Host drives `bit`; returns (targetData, targetOe) as the host
+    * would sample them during the low phase (i.e. what the target registered on the
+    * previous rising edge). */
+  def step(bit: Boolean): (Boolean, Boolean) = {
+    cd.fallingEdge(); sleep(1)
+    swdioI #= bit
+    sleep(1)
+    val oe = swdioOe.toBoolean
+    val o  = swdioO.toBoolean
+    cd.risingEdge(); sleep(2)
+    (o, oe)
+  }
+
+  def idle(n: Int): Unit = for (_ <- 0 until n) step(false)
+  def ones(n: Int): Unit = for (_ <- 0 until n) step(true)
+  def lineReset(): Unit = { ones(52); idle(2) }
+
+  /** 8-bit packet request, LSB first. The target must not drive during it. */
+  def header(apNdp: Boolean, rnw: Boolean, addr: Int,
+             flipParity: Boolean = false, badStop: Boolean = false, badPark: Boolean = false): Unit = {
+    val a2 = (addr & 1) != 0
+    val a3 = (addr & 2) != 0
+    val par = (apNdp ^ rnw ^ a2 ^ a3) ^ flipParity
+    val bits = Seq(true, apNdp, rnw, a2, a3, par, badStop, !badPark)
+    for (b <- bits) {
+      val (_, oe) = step(b)
+      assert(!oe, "target must not drive during the packet request")
+    }
+  }
+
+  def readTargetBit(): (Boolean, Boolean) = step(false)
+
+  def readAck(): (Int, Boolean) = {
+    var v = 0
+    var oeAll = true
+    for (i <- 0 until 3) {
+      val (b, oe) = readTargetBit()
+      if (b) v |= 1 << i
+      oeAll &= oe
+    }
+    (v, oeAll)
+  }
+
+  def transactRead(apNdp: Boolean, addr: Int): (Int, Option[BigInt]) = {
+    header(apNdp, rnw = true, addr)
+    step(false)                                   // turnaround host -> target
+    val (ack, ackOe) = readAck()
+    assert(ackOe, "target must drive all 3 ACK bits")
+    if (ack == OK) {
+      var data = BigInt(0)
+      var oeAll = true
+      for (i <- 0 until 32) {
+        val (b, oe) = readTargetBit()
+        if (b) data |= BigInt(1) << i
+        oeAll &= oe
+      }
+      val (pBit, pOe) = readTargetBit()
+      oeAll &= pOe
+      assert(oeAll, "target must drive all 33 data-phase bits")
+      val parityCalc = (0 until 32).map(i => ((data >> i) & 1) != 0).reduce(_ ^ _)
+      assert(parityCalc == pBit, "read data parity mismatch")
+      val (_, trnOe) = step(false)                // turnaround target -> host
+      assert(!trnOe, "target must release the line after the read data phase")
+      (ack, Some(data))
+    } else {
+      val (_, oeAfter) = step(false)
+      assert(!oeAfter, s"data phase must be skipped on WAIT/FAULT (ack=$ack)")
+      (ack, None)
+    }
+  }
+
+  def transactWrite(apNdp: Boolean, addr: Int, data: BigInt,
+                    flipDataParity: Boolean = false): Int = {
+    header(apNdp, rnw = false, addr)
+    step(false)                                   // turnaround host -> target
+    val (ack, ackOe) = readAck()
+    assert(ackOe, "target must drive all 3 ACK bits")
+    if (ack == OK) {
+      val (_, trnOe) = step(false)                // turnaround target -> host
+      assert(!trnOe, "target must release the line before WDATA")
+      var par = false
+      for (i <- 0 until 32) {
+        val b = ((data >> i) & 1) != 0
+        par ^= b
+        step(b)
+      }
+      step(par ^ flipDataParity)
+    } else {
+      val (_, oeAfter) = step(false)
+      assert(!oeAfter, s"data phase must be skipped on WAIT/FAULT (ack=$ack)")
+    }
+    ack
+  }
+}


### PR DESCRIPTION
Wire DebugTransportModuleSwd into VexRiscvSmpCluster as an alternative to the JTAG DTM (--swd, mutually exclusive with --jtag-tap, requires privilegedDebug) and expose SWCLK/SWDIO as LiteX black-box ports.

Add SpinalSim coverage for the SWD wire protocol, DP, and DM, plus a shared host bitbang driver.